### PR TITLE
feat: remove change detection strategy from all components

### DIFF
--- a/demo/demo.component.ts
+++ b/demo/demo.component.ts
@@ -1,4 +1,4 @@
-import { Component } from '@angular/core';
+import { Component, ChangeDetectionStrategy } from '@angular/core';
 import {
   startOfDay,
   subDays,
@@ -36,6 +36,7 @@ const colors: any = {
 
 @Component({
   selector: 'mwl-demo-app',
+  changeDetection: ChangeDetectionStrategy.OnPush,
   styles: [`
     h3 {
       margin: 0;

--- a/src/components/day/calendarDayView.component.ts
+++ b/src/components/day/calendarDayView.component.ts
@@ -1,6 +1,5 @@
 import {
   Component,
-  ChangeDetectionStrategy,
   Input,
   OnChanges,
   Output,
@@ -20,7 +19,6 @@ const SEGMENT_HEIGHT: number = 30;
 
 @Component({
   selector: 'mwl-calendar-day-view',
-  changeDetection: ChangeDetectionStrategy.OnPush,
   template: `
     <div class="cal-day-view">
       <mwl-calendar-all-day-event

--- a/src/components/month/calendarMonthView.component.ts
+++ b/src/components/month/calendarMonthView.component.ts
@@ -4,7 +4,6 @@ import {
   Input,
   Output,
   EventEmitter,
-  ChangeDetectionStrategy,
   ChangeDetectorRef,
   OnInit,
   OnDestroy,
@@ -25,7 +24,6 @@ import isSameDay from 'date-fns/is_same_day';
 
 @Component({
   selector: 'mwl-calendar-month-view',
-  changeDetection: ChangeDetectionStrategy.OnPush,
   template: `
     <div class="cal-month-view">
       <div class="cal-cell-row cal-header">

--- a/src/components/week/calendarWeekView.component.ts
+++ b/src/components/week/calendarWeekView.component.ts
@@ -3,7 +3,6 @@ import {
   Input,
   Output,
   EventEmitter,
-  ChangeDetectionStrategy,
   ChangeDetectorRef,
   OnChanges,
   OnInit,
@@ -27,7 +26,6 @@ import { CalendarEventTimesChangedEvent } from './../../interfaces/calendarEvent
 
 @Component({
   selector: 'mwl-calendar-week-view',
-  changeDetection: ChangeDetectionStrategy.OnPush,
   template: `
     <div class="cal-week-view">
       <div class="cal-day-headers">


### PR DESCRIPTION
BREAKING CHANGE:

For enhanced performance it is recommended that you add `changeDetection: ChangeDetectionStrategy.OnPush` on all components that use this library. This will restrict change detection to only run when the components inputs change

Closes #94