### PR TITLE
fix: Convert strings to numbers

### DIFF
--- a/src/components/day/calendarDayView.component.ts
+++ b/src/components/day/calendarDayView.component.ts
@@ -395,14 +395,14 @@ export class CalendarDayViewComponent implements OnChanges, OnInit, OnDestroy {
   private refreshHourGrid(): void {
     this.hours = this.utils.getDayViewHourGrid({
       viewDate: this.viewDate,
-      hourSegments: this.hourSegments,
+      hourSegments: +this.hourSegments,
       dayStart: {
-        hour: this.dayStartHour,
-        minute: this.dayStartMinute
+        hour: +this.dayStartHour,
+        minute: +this.dayStartMinute
       },
       dayEnd: {
-        hour: this.dayEndHour,
-        minute: this.dayEndMinute
+        hour: +this.dayEndHour,
+        minute: +this.dayEndMinute
       }
     });
     this.beforeViewRender.emit({
@@ -414,16 +414,16 @@ export class CalendarDayViewComponent implements OnChanges, OnInit, OnDestroy {
     this.view = this.utils.getDayView({
       events: this.events,
       viewDate: this.viewDate,
-      hourSegments: this.hourSegments,
+      hourSegments: +this.hourSegments,
       dayStart: {
-        hour: this.dayStartHour,
-        minute: this.dayStartMinute
+        hour: +this.dayStartHour,
+        minute: +this.dayStartMinute
       },
       dayEnd: {
-        hour: this.dayEndHour,
-        minute: this.dayEndMinute
+        hour: +this.dayEndHour,
+        minute: +this.dayEndMinute
       },
-      eventWidth: this.eventWidth,
+      eventWidth: +this.eventWidth,
       segmentHeight: SEGMENT_HEIGHT
     });
   }


### PR DESCRIPTION
If you used the calendar without binding, the values were treated as strings, and the strings were added like `200+150` which meant `200150px` width.

This happened in a code like this:

```html
 <mwl-calendar-day-view
  [viewDate]="viewDate"
  [events]="events"
  eventWidth="200">
 </mwl-calendar-day-view>
 ```