### PR TITLE
chore: add support for custom container css class

### DIFF
--- a/src/components/day/calendarDayView.component.ts
+++ b/src/components/day/calendarDayView.component.ts
@@ -72,6 +72,7 @@ export interface DayViewEventResize {
             #event
             *ngFor="let dayEvent of view?.events"
             class="cal-event-container"
+            [ngClass]="dayEvent.event?.containerCssClass"
             [class.cal-draggable]="dayEvent.event.draggable"
             mwlResizable
             [resizeEdges]="{top: dayEvent.event?.resizable?.beforeStart, bottom: dayEvent.event?.resizable?.afterEnd}"


### PR DESCRIPTION
This `cal-event-container` was not present in the older versions.
Let's add a way to customize it, similar to how we do it for the event itself (with `cssClass`).
Thanks!