### PR TITLE
fix(day-view): prevent selection when dragging cal-event

### DIFF
--- a/src/modules/day/calendar-day-view.scss
+++ b/src/modules/day/calendar-day-view.scss
@@ -58,12 +58,7 @@
     background-color: #D1E8FF;
     border: 1px solid #1e90ff;
     color: #1e90ff;
-    -webkit-touch-callout: none;
-      -webkit-user-select: none;
-       -khtml-user-select: none;
-         -moz-user-select: none;
-          -ms-user-select: none;
-              user-select: none;
+    user-select: none;
   }
 
   .cal-event-title:link {

--- a/src/modules/day/calendar-day-view.scss
+++ b/src/modules/day/calendar-day-view.scss
@@ -58,6 +58,12 @@
     background-color: #D1E8FF;
     border: 1px solid #1e90ff;
     color: #1e90ff;
+    -webkit-touch-callout: none;
+      -webkit-user-select: none;
+       -khtml-user-select: none;
+         -moz-user-select: none;
+          -ms-user-select: none;
+              user-select: none;
   }
 
   .cal-event-title:link {


### PR DESCRIPTION
Fixes issue where hour labels would be selected while dragging a day event.

The picture below demonstrates the issue reproduced on the official demo page.

![image](https://user-images.githubusercontent.com/38946115/39580054-80c2d872-4ee8-11e8-9962-69d24b10af30.png)
