### PR TITLE
fix(event-click): clicking actual events now triggers eventClicked

### DIFF
--- a/src/modules/day/calendar-all-day-event.component.ts
+++ b/src/modules/day/calendar-all-day-event.component.ts
@@ -17,14 +17,14 @@ import { CalendarEvent } from 'calendar-utils';
       <div
         class="cal-all-day-event"
         [style.backgroundColor]="event.color?.secondary"
-        [style.borderColor]="event.color?.primary">
+        [style.borderColor]="event.color?.primary"
+        (mwlClick)="eventClicked.emit()">
         <mwl-calendar-event-actions [event]="event"></mwl-calendar-event-actions>
         &ngsp;
         <mwl-calendar-event-title
           [event]="event"
           [customTemplate]="eventTitleTemplate"
-          view="day"
-          (mwlClick)="eventClicked.emit()">
+          view="day">
         </mwl-calendar-event-title>
       </div>
     </ng-template>

--- a/src/modules/day/calendar-day-view-event.component.ts
+++ b/src/modules/day/calendar-day-view-event.component.ts
@@ -25,14 +25,14 @@ import { DayViewEvent } from 'calendar-utils';
         [tooltipPlacement]="tooltipPlacement"
         [tooltipEvent]="dayEvent.event"
         [tooltipTemplate]="tooltipTemplate"
-        [tooltipAppendToBody]="tooltipAppendToBody">
+        [tooltipAppendToBody]="tooltipAppendToBody"
+        (mwlClick)="eventClicked.emit()">
         <mwl-calendar-event-actions [event]="dayEvent.event"></mwl-calendar-event-actions>
         &ngsp;
         <mwl-calendar-event-title
           [event]="dayEvent.event"
           [customTemplate]="eventTitleTemplate"
-          view="day"
-          (mwlClick)="eventClicked.emit()">
+          view="day">
         </mwl-calendar-event-title>
       </div>
     </ng-template>

--- a/src/modules/day/calendar-day-view-event.component.ts
+++ b/src/modules/day/calendar-day-view-event.component.ts
@@ -26,7 +26,7 @@ import { DayViewEvent } from 'calendar-utils';
         [tooltipEvent]="dayEvent.event"
         [tooltipTemplate]="tooltipTemplate"
         [tooltipAppendToBody]="tooltipAppendToBody"
-        (mwlClick)="eventClicked.emit()">
+        (mwlClick)="handleEventClick($event)">
         <mwl-calendar-event-actions [event]="dayEvent.event"></mwl-calendar-event-actions>
         &ngsp;
         <mwl-calendar-event-title
@@ -62,4 +62,17 @@ export class CalendarDayViewEventComponent {
   @Input() tooltipTemplate: TemplateRef<any>;
 
   @Output() eventClicked: EventEmitter<any> = new EventEmitter();
+
+  /**
+   * @hidden
+   */
+  handleEventClick(clickEvent: any) {
+    // only fire click event when clicked on host element or title therein, ignore other underlying elements
+    if (
+      clickEvent.target.classList.contains('cal-event') ||
+      clickEvent.target.classList.contains('cal-event-title')
+    ) {
+      this.eventClicked.emit();
+    }
+  }
 }

--- a/src/modules/day/calendar-day-view.scss
+++ b/src/modules/day/calendar-day-view.scss
@@ -59,13 +59,14 @@
     border: 1px solid #1e90ff;
     color: #1e90ff;
     user-select: none;
+    cursor: pointer;
   }
 
   .cal-event-title:link {
     color: currentColor;
   }
 
-  .cal-draggable {
+  .cal-draggable .cal-event {
     cursor: move;
   }
 
@@ -82,5 +83,6 @@
   .cal-all-day-event {
     padding: 8px;
     border: solid 1px;
+    cursor: pointer;
   }
 }

--- a/src/modules/week/calendar-week-view-event.component.ts
+++ b/src/modules/week/calendar-week-view-event.component.ts
@@ -25,14 +25,14 @@ import { WeekViewEvent } from 'calendar-utils';
         [tooltipPlacement]="tooltipPlacement"
         [tooltipEvent]="weekEvent.event"
         [tooltipTemplate]="tooltipTemplate"
-        [tooltipAppendToBody]="tooltipAppendToBody">
+        [tooltipAppendToBody]="tooltipAppendToBody"
+        (mwlClick)="eventClicked.emit()">
         <mwl-calendar-event-actions [event]="weekEvent.event"></mwl-calendar-event-actions>
         &ngsp;
         <mwl-calendar-event-title
           [event]="weekEvent.event"
           [customTemplate]="eventTitleTemplate"
-          view="week"
-          (mwlClick)="eventClicked.emit()">
+          view="week">
         </mwl-calendar-event-title>
       </div>
     </ng-template>

--- a/src/modules/week/calendar-week-view-event.component.ts
+++ b/src/modules/week/calendar-week-view-event.component.ts
@@ -26,7 +26,7 @@ import { WeekViewEvent } from 'calendar-utils';
         [tooltipEvent]="weekEvent.event"
         [tooltipTemplate]="tooltipTemplate"
         [tooltipAppendToBody]="tooltipAppendToBody"
-        (mwlClick)="eventClicked.emit()">
+        (mwlClick)="handleEventClick($event)">
         <mwl-calendar-event-actions [event]="weekEvent.event"></mwl-calendar-event-actions>
         &ngsp;
         <mwl-calendar-event-title
@@ -62,4 +62,17 @@ export class CalendarWeekViewEventComponent {
   @Input() tooltipTemplate: TemplateRef<any>;
 
   @Output() eventClicked: EventEmitter<any> = new EventEmitter();
+
+  /**
+   * @hidden
+   */
+  handleEventClick(clickEvent: any) {
+    // only fire click event when clicked on host element or title therein, ignore other underlying elements
+    if (
+      clickEvent.target.classList.contains('cal-event') ||
+      clickEvent.target.classList.contains('cal-event-title')
+    ) {
+      this.eventClicked.emit();
+    }
+  }
 }

--- a/src/modules/week/calendar-week-view.scss
+++ b/src/modules/week/calendar-week-view.scss
@@ -47,13 +47,14 @@
     background-color: #d1e8ff;
     border: 1px solid #1e90ff;
     color: #1e90ff;
+    cursor: pointer;
   }
 
   .cal-event-title:link {
     color: currentColor;
   }
 
-  .cal-draggable {
+  .cal-draggable .cal-event {
     cursor: move;
   }
 


### PR DESCRIPTION
Event titles used to only trigger eventClicked events. This doesn't make sense, so trigger eventClicked when the actual event item (week or day) is clicked.