### PR TITLE
fix: changed the datetime format to ISO8601 standard

### DIFF
--- a/projects/demos/app/demo-modules/async-events/component.ts
+++ b/projects/demos/app/demo-modules/async-events/component.ts
@@ -29,7 +29,8 @@ function getTimezoneOffsetString(date: Date): string {
   ).padStart(2, '0');
   const minutesOffset = String(Math.abs(timezoneOffset % 60)).padEnd(2, '0');
   const direction = timezoneOffset > 0 ? '-' : '+';
-  return `T00:00:00${direction}${hoursOffset}${minutesOffset}`;
+
+  return `T00:00:00${direction}${hoursOffset}:${minutesOffset}`;
 }
 
 @Component({


### PR DESCRIPTION
Previous datetime+offset format - RFC 822 is not correctly parsed by Safari. Changed the format to conform to ISO8601 which works in all browsers.

Fixes: #883 