### PR TITLE
fix(month-view): make slide animation smoother

### DIFF
--- a/projects/angular-calendar/src/modules/month/calendar-open-day-events.component.ts
+++ b/projects/angular-calendar/src/modules/month/calendar-open-day-events.component.ts
@@ -8,6 +8,7 @@ import {
 import {
   trigger,
   style,
+  state,
   transition,
   animate,
   AnimationTriggerMetadata
@@ -16,14 +17,26 @@ import { CalendarEvent } from 'calendar-utils';
 import { trackByEventId } from '../common/util';
 
 export const collapseAnimation: AnimationTriggerMetadata = trigger('collapse', [
-  transition('void => *', [
-    style({ height: 0, overflow: 'hidden' }),
-    animate('150ms', style({ height: '*' }))
-  ]),
-  transition('* => void', [
-    style({ height: '*', overflow: 'hidden' }),
-    animate('150ms', style({ height: 0 }))
-  ])
+  state(
+    'void',
+    style({
+      height: 0,
+      overflow: 'hidden',
+      'padding-top': 0,
+      'padding-bottom': 0
+    })
+  ),
+  state(
+    '*',
+    style({
+      height: '*',
+      overflow: 'hidden',
+      'padding-top': '*',
+      'padding-bottom': '*'
+    })
+  ),
+  transition('* => void', animate('150ms ease-out')),
+  transition('void => *', animate('150ms ease-in'))
 ]);
 
 @Component({


### PR DESCRIPTION
When I try to use the calendar on [the demo](https://mattlewis92.github.io/angular-calendar/#/kitchen-sink), I click on day to toggle day events. I have seen that the day events container transitioning a little bit lagging. The element contain padding, but looks like there is only a transition for the height.