### PR TITLE
Fix #1032

### DIFF
--- a/projects/angular-calendar/src/modules/day/calendar-day-view.component.ts
+++ b/projects/angular-calendar/src/modules/day/calendar-day-view.component.ts
@@ -482,7 +482,8 @@ export class CalendarDayViewComponent implements OnChanges, OnInit, OnDestroy {
       changes.dayStartMinute ||
       changes.dayEndHour ||
       changes.dayEndMinute ||
-      changes.eventWidth;
+      changes.eventWidth  ||
+      changes.hourSegments;
 
     if (refreshHourGrid) {
       this.refreshHourGrid();


### PR DESCRIPTION
When hourSegments is updated on the Day View Component, refresh the view too instead of just the hour grid.