### PR TITLE
fix: correct movement for events in view day scheduler

### DIFF
--- a/projects/angular-calendar/src/modules/common/util.ts
+++ b/projects/angular-calendar/src/modules/common/util.ts
@@ -32,6 +32,14 @@ export function roundToNearest(amount: number, precision: number) {
   return Math.round(amount / precision) * precision;
 }
 
+export function roundToNearestForDragEnded(amount: number, precision: number) {
+  if (precision > amount) {
+    return 0;
+} else {
+    return Math.round(amount / precision) * precision;
+}
+}
+
 export const trackByEventId = (index: number, event: CalendarEvent) =>
   event.id ? event.id : event;
 

--- a/projects/angular-calendar/src/modules/week/calendar-week-view.component.ts
+++ b/projects/angular-calendar/src/modules/week/calendar-week-view.component.ts
@@ -35,6 +35,7 @@ import { CalendarUtils } from '../common/calendar-utils.provider';
 import {
   validateEvents,
   roundToNearest,
+  roundToNearestForDragEnded,
   trackByWeekDayHeaderDate,
   trackByHourSegment,
   trackByHour,
@@ -1153,7 +1154,7 @@ export class CalendarWeekViewComponent implements OnChanges, OnInit, OnDestroy {
     dayWidth: number,
     useY: boolean
   ) {
-    const daysDragged = roundToNearest(dragEndEvent.x, dayWidth) / dayWidth;
+    const daysDragged = roundToNearestForDragEnded(dragEndEvent.x, dayWidth) / dayWidth;
     const minutesMoved = useY
       ? getMinutesMoved(
           dragEndEvent.y,


### PR DESCRIPTION
In our project we use this plagin. It's cool! And thank's you for your work!
But I have some problem...
I use example Day view scheduler in my app. And when users.lenght > 5, 
and i want to move event from first to last user (also change start and end time -> moving event to right and up or down). In finally only changing user, not time for event.
Because, when users a lot and distance(dragEvent.x) also big, function  roundToNearest, which calculate Math.round,  return 1 and this change normal behavior.

I could solve problem, when added custom function, which return 0.
I run test in project and unfortunately some of them was failed. Please,  help me in my problem.
![picture1](https://user-images.githubusercontent.com/45772424/69486905-7f16b580-0e62-11ea-825d-9687176b3878.PNG)

