### PR TITLE
fix: solved Ivy compatibility issue

### DIFF
--- a/projects/angular-calendar/src/modules/common/calendar-event-actions.component.ts
+++ b/projects/angular-calendar/src/modules/common/calendar-event-actions.component.ts
@@ -29,14 +29,14 @@ import { CalendarEvent, EventAction } from 'calendar-utils';
         </a>
       </span>
     </ng-template>
-    <ng-template
+    <ng-container
       [ngTemplateOutlet]="customTemplate || defaultTemplate"
       [ngTemplateOutletContext]="{
         event: event,
         trackByActionId: trackByActionId
       }"
     >
-    </ng-template>
+    </ng-container>
   `
 })
 export class CalendarEventActionsComponent {

--- a/projects/angular-calendar/src/modules/common/calendar-event-title.component.ts
+++ b/projects/angular-calendar/src/modules/common/calendar-event-title.component.ts
@@ -12,14 +12,14 @@ import { CalendarEvent } from 'calendar-utils';
       >
       </span>
     </ng-template>
-    <ng-template
+    <ng-container
       [ngTemplateOutlet]="customTemplate || defaultTemplate"
       [ngTemplateOutletContext]="{
         event: event,
         view: view
       }"
     >
-    </ng-template>
+    </ng-container>
   `
 })
 export class CalendarEventTitleComponent {

--- a/projects/angular-calendar/src/modules/common/calendar-tooltip.directive.ts
+++ b/projects/angular-calendar/src/modules/common/calendar-tooltip.directive.ts
@@ -36,7 +36,7 @@ import { takeUntil } from 'rxjs/operators';
         <div class="cal-tooltip-inner" [innerHtml]="contents"></div>
       </div>
     </ng-template>
-    <ng-template
+    <ng-container
       [ngTemplateOutlet]="customTemplate || defaultTemplate"
       [ngTemplateOutletContext]="{
         contents: contents,
@@ -44,7 +44,7 @@ import { takeUntil } from 'rxjs/operators';
         event: event
       }"
     >
-    </ng-template>
+    </ng-container>
   `
 })
 export class CalendarTooltipWindowComponent {

--- a/projects/angular-calendar/src/modules/month/calendar-month-cell.component.ts
+++ b/projects/angular-calendar/src/modules/month/calendar-month-cell.component.ts
@@ -69,7 +69,7 @@ import { PlacementArray } from 'positioning';
         ></div>
       </div>
     </ng-template>
-    <ng-template
+    <ng-container
       [ngTemplateOutlet]="customTemplate || defaultTemplate"
       [ngTemplateOutletContext]="{
         day: day,
@@ -86,7 +86,7 @@ import { PlacementArray } from 'positioning';
         validateDrag: validateDrag
       }"
     >
-    </ng-template>
+    </ng-container>
   `,
   host: {
     class: 'cal-cell cal-day-cell',

--- a/projects/angular-calendar/src/modules/month/calendar-month-view-header.component.ts
+++ b/projects/angular-calendar/src/modules/month/calendar-month-view-header.component.ts
@@ -39,7 +39,7 @@ import { trackByWeekDayHeaderDate } from '../common/util';
         </div>
       </div>
     </ng-template>
-    <ng-template
+    <ng-container
       [ngTemplateOutlet]="customTemplate || defaultTemplate"
       [ngTemplateOutletContext]="{
         days: days,
@@ -47,7 +47,7 @@ import { trackByWeekDayHeaderDate } from '../common/util';
         trackByWeekDayHeaderDate: trackByWeekDayHeaderDate
       }"
     >
-    </ng-template>
+    </ng-container>
   `
 })
 export class CalendarMonthViewHeaderComponent {

--- a/projects/angular-calendar/src/modules/month/calendar-open-day-events.component.ts
+++ b/projects/angular-calendar/src/modules/month/calendar-open-day-events.component.ts
@@ -113,7 +113,7 @@ export const collapseAnimation: AnimationTriggerMetadata = trigger('collapse', [
         </div>
       </div>
     </ng-template>
-    <ng-template
+    <ng-container
       [ngTemplateOutlet]="customTemplate || defaultTemplate"
       [ngTemplateOutletContext]="{
         events: events,
@@ -123,7 +123,7 @@ export const collapseAnimation: AnimationTriggerMetadata = trigger('collapse', [
         validateDrag: validateDrag
       }"
     >
-    </ng-template>
+    </ng-container>
   `,
   animations: [collapseAnimation]
 })

--- a/projects/angular-calendar/src/modules/week/calendar-week-view-current-time-marker.component.ts
+++ b/projects/angular-calendar/src/modules/week/calendar-week-view-current-time-marker.component.ts
@@ -28,7 +28,7 @@ import { DateAdapter } from '../../date-adapters/date-adapter';
         [style.top.px]="topPx"
       ></div>
     </ng-template>
-    <ng-template
+    <ng-container
       [ngTemplateOutlet]="customTemplate || defaultTemplate"
       [ngTemplateOutletContext]="{
         columnDate: columnDate,
@@ -40,7 +40,7 @@ import { DateAdapter } from '../../date-adapters/date-adapter';
         topPx: (marker$ | async)?.top
       }"
     >
-    </ng-template>
+    </ng-container>
   `
 })
 export class CalendarWeekViewCurrentTimeMarkerComponent implements OnChanges {

--- a/projects/angular-calendar/src/modules/week/calendar-week-view-event.component.ts
+++ b/projects/angular-calendar/src/modules/week/calendar-week-view-event.component.ts
@@ -69,7 +69,7 @@ import { PlacementArray } from 'positioning';
         </mwl-calendar-event-title>
       </div>
     </ng-template>
-    <ng-template
+    <ng-container
       [ngTemplateOutlet]="customTemplate || defaultTemplate"
       [ngTemplateOutletContext]="{
         weekEvent: weekEvent,
@@ -83,7 +83,7 @@ import { PlacementArray } from 'positioning';
         daysInWeek: daysInWeek
       }"
     >
-    </ng-template>
+    </ng-container>
   `
 })
 export class CalendarWeekViewEventComponent {

--- a/projects/angular-calendar/src/modules/week/calendar-week-view-header.component.ts
+++ b/projects/angular-calendar/src/modules/week/calendar-week-view-header.component.ts
@@ -50,7 +50,7 @@ import { trackByWeekDayHeaderDate } from '../common/util';
         </div>
       </div>
     </ng-template>
-    <ng-template
+    <ng-container
       [ngTemplateOutlet]="customTemplate || defaultTemplate"
       [ngTemplateOutletContext]="{
         days: days,
@@ -61,7 +61,7 @@ import { trackByWeekDayHeaderDate } from '../common/util';
         trackByWeekDayHeaderDate: trackByWeekDayHeaderDate
       }"
     >
-    </ng-template>
+    </ng-container>
   `
 })
 export class CalendarWeekViewHeaderComponent {

--- a/projects/angular-calendar/src/modules/week/calendar-week-view-hour-segment.component.ts
+++ b/projects/angular-calendar/src/modules/week/calendar-week-view-hour-segment.component.ts
@@ -36,7 +36,7 @@ import { WeekViewHourSegment } from 'calendar-utils';
         </div>
       </div>
     </ng-template>
-    <ng-template
+    <ng-container
       [ngTemplateOutlet]="customTemplate || defaultTemplate"
       [ngTemplateOutletContext]="{
         segment: segment,
@@ -46,7 +46,7 @@ import { WeekViewHourSegment } from 'calendar-utils';
         daysInWeek: daysInWeek
       }"
     >
-    </ng-template>
+    </ng-container>
   `
 })
 export class CalendarWeekViewHourSegmentComponent {


### PR DESCRIPTION
With these changes I can correctly compile my app with Ivy enabled. Followed indications on https://angular.io/api/common/NgTemplateOutlet, it seems the same directive is not supported on ng-templates anymore.

Fixes #1161