### PR TITLE
fix: use locale aware day view title for moment date formatter

### DIFF
--- a/projects/angular-calendar/src/modules/common/calendar-moment-date-formatter.provider.ts
+++ b/projects/angular-calendar/src/modules/common/calendar-moment-date-formatter.provider.ts
@@ -118,6 +118,6 @@ export class CalendarMomentDateFormatter
    * The day view title
    */
   public dayViewTitle({ date, locale }: DateFormatterParams): string {
-    return this.moment(date).locale(locale).format('dddd, D MMMM, YYYY');
-  }
+    return this.moment(date).locale(locale).format('dddd, LL'); // dddd = Thursday
+  }                                                             // LL = locale-dependent Month Day, Year
 }

--- a/projects/angular-calendar/test/calendar-moment-date-formatter.provider.spec.ts
+++ b/projects/angular-calendar/test/calendar-moment-date-formatter.provider.spec.ts
@@ -105,6 +105,6 @@ describe('calendarMomentDateFormatter provider', () => {
   it('dayViewTitle', () => {
     expect(
       dateFormatter.dayViewTitle({ date: new Date('2016-01-01'), locale: 'en' })
-    ).to.equal('Friday, 1 January, 2016');
+    ).to.equal('Friday, January 1, 2016');
   });
 });


### PR DESCRIPTION
Closes #1396

`dayViewTitle` changed to use `dddd, LL` formatting.

`dddd` = full day name (i.e Thursday)
`LL` = locale-dependent Month Day, Year (i.e January 21, 2021...but sometimes 21 January, 2021)