### PR TITLE
fix: restore compatibility with jest 28

### DIFF
--- a/package.json
+++ b/package.json
@@ -184,16 +184,25 @@
   ],
   "exports": {
     "./date-adapters/date-adapter": {
-      "types": "./date-adapters/esm/date-adapter.d.ts",
-      "default": "./date-adapters/esm/date-adapter.js"
+      "main": "./date-adapters/index.js",
+      "types": "./date-adapters/index.d.ts",
+      "default": "./date-adapters/esm/date-adapter.js",
+      "require": "./date-adapters/index.js",
+      "import": "./date-adapters/esm/date-adapter.js"
     },
     "./date-adapters/date-fns": {
-      "types": "./date-adapters/esm/date-fns/index.d.ts",
-      "default": "./date-adapters/esm/date-fns/index.js"
+      "main": "./date-adapters/date-fns/index.js",
+      "types": "./date-adapters/date-fns/index.d.ts",
+      "default": "./date-adapters/esm/date-fns/index.js",
+      "require": "./date-adapters/date-fns/index.js",
+      "import": "./date-adapters/esm/date-fns/index.js"
     },
     "./date-adapters/moment": {
-      "types": "./date-adapters/esm/moment/index.d.ts",
-      "default": "./date-adapters/esm/moment/index.js"
+      "main": "./date-adapters/moment/index.js",
+      "types": "./date-adapters/moment/index.d.ts",
+      "default": "./date-adapters/esm/moment/index.js",
+      "require": "./date-adapters/moment/index.js",
+      "import": "./date-adapters/esm/moment/index.js"
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -188,21 +188,33 @@
       "types": "./date-adapters/index.d.ts",
       "default": "./date-adapters/esm/date-adapter.js",
       "require": "./date-adapters/index.js",
-      "import": "./date-adapters/esm/date-adapter.js"
+      "import": "./date-adapters/esm/date-adapter.js",
+      "es2020": "./date-adapters/esm/date-adapter.js",
+      "esm2020": "./date-adapters/esm/date-adapter.js",
+      "fesm2020": "./date-adapters/esm/date-adapter.js",
+      "fesm2015": "./date-adapters/esm/date-adapter.js"
     },
     "./date-adapters/date-fns": {
       "main": "./date-adapters/date-fns/index.js",
       "types": "./date-adapters/date-fns/index.d.ts",
       "default": "./date-adapters/esm/date-fns/index.js",
       "require": "./date-adapters/date-fns/index.js",
-      "import": "./date-adapters/esm/date-fns/index.js"
+      "import": "./date-adapters/esm/date-fns/index.js",
+      "es2020": "./date-adapters/esm/date-fns/index.js",
+      "esm2020": "./date-adapters/esm/date-fns/index.js",
+      "fesm2020": "./date-adapters/esm/date-fns/index.js",
+      "fesm2015": "./date-adapters/esm/date-fns/index.js"
     },
     "./date-adapters/moment": {
       "main": "./date-adapters/moment/index.js",
       "types": "./date-adapters/moment/index.d.ts",
       "default": "./date-adapters/esm/moment/index.js",
       "require": "./date-adapters/moment/index.js",
-      "import": "./date-adapters/esm/moment/index.js"
+      "import": "./date-adapters/esm/moment/index.js",
+      "es2020": "./date-adapters/esm/moment/index.js",
+      "esm2020": "./date-adapters/esm/moment/index.js",
+      "fesm2020": "./date-adapters/esm/moment/index.js",
+      "fesm2015": "./date-adapters/esm/moment/index.js"
     }
   }
 }


### PR DESCRIPTION
Fixes the adaptors export. Current export has issues when running in a jest 28 testing environment due to the ESM resolution. 

Example error:

```
...

    Details:

    /home/circleci/code/node_modules/angular-calendar/date-adapters/esm/date-fns/index.js:1
    ({"Object.<anonymous>":function(module,exports,require,__dirname,__filename,jest){import { __assign } from "tslib";
                                                                                      ^^^^^^

    SyntaxError: Cannot use import statement outside a module
...
```

https://app.circleci.com/pipelines/github/dereekb/dbx-components/1530/workflows/fdecd446-eb34-4ba3-8f42-d4917aa8eb56/jobs/4210/parallel-runs/0/steps/0-110

This change allows Jest/CommonJS to import the date-adapters via require(). This change does not impact Angular builds that utilize ESM.