### PR TITLE
fix(week-view): allDayEventsLabelTemplate rendered outside of container

### DIFF
--- a/projects/angular-calendar/src/modules/week/calendar-week-view/calendar-week-view.component.ts
+++ b/projects/angular-calendar/src/modules/week/calendar-week-view/calendar-week-view.component.ts
@@ -103,10 +103,11 @@ export interface CalendarWeekViewBeforeRenderEvent extends WeekView {
         (dragLeave)="dragLeave('allDay')"
       >
         <div class="cal-day-columns">
-          <div
-            class="cal-time-label-column"
-            [ngTemplateOutlet]="allDayEventsLabelTemplate"
-          ></div>
+          <div class="cal-time-label-column">
+            <ng-container
+              *ngTemplateOutlet="allDayEventsLabelTemplate"
+            ></ng-container>
+          </div>
           <div
             class="cal-day-column"
             *ngFor="let day of days; trackBy: trackByWeekDayHeaderDate"


### PR DESCRIPTION
Hi @mattlewis92,

Thank you for the fantastic work you've done on the angular-calendar. I appreciate the effort you've put into maintaining it.

I noticed a minor issue. The allDayEventsLabelTemplate was rendered outside the .cal-time-label-column element. I've made a small adjustment to ensure that the template is rendered within the intended div element.

<img width="729" alt="Screenshot 2024-03-04 at 14 39 03" src="https://github.com/mattlewis92/angular-calendar/assets/2027106/9ca92838-cd5d-4a77-b83a-74a9ae421a83">


Best regards,
Michael