### PR TITLE
feat: add luxon date adapter

### DIFF
--- a/package.json
+++ b/package.json
@@ -216,6 +216,17 @@
       "fesm2015": "./date-adapters/esm/moment/index.js",
       "default": "./date-adapters/esm/moment/index.js"
     },
+    "./date-adapters/luxon": {
+      "main": "./date-adapters/luxon/index.js",
+      "types": "./date-adapters/luxon/index.d.ts",
+      "require": "./date-adapters/luxon/index.js",
+      "import": "./date-adapters/esm/luxon/index.js",
+      "es2020": "./date-adapters/esm/luxon/index.js",
+      "esm2020": "./date-adapters/esm/luxon/index.js",
+      "fesm2020": "./date-adapters/esm/luxon/index.js",
+      "fesm2015": "./date-adapters/esm/luxon/index.js",
+      "default": "./date-adapters/esm/luxon/index.js"
+    },
     "./scss/*": {
       "sass": "./scss/*"
     }

--- a/projects/angular-calendar/schematics/ng-add/index.ts
+++ b/projects/angular-calendar/schematics/ng-add/index.ts
@@ -32,6 +32,7 @@ import {
 import { Schema } from './schema';
 import {
   dateFnsVersion,
+  luxonVersion,
   momentVersion,
   angularCalendarVersion,
 } from './version-names';
@@ -59,6 +60,7 @@ function addPackageJsonDependencies(options: Schema): Rule {
     const dateAdapters: { [key: string]: string } = {
       moment: momentVersion,
       'date-fns': dateFnsVersion,
+      'luxon': luxonVersion,
     };
 
     const angularCalendarDependency: NodeDependency = nodeDependencyFactory(
@@ -113,7 +115,7 @@ function addModuleToImports(options: Schema): Rule {
     const moduleName = `CalendarModule.forRoot({ provide: DateAdapter, useFactory: ${
       options.dateAdapter === 'moment'
         ? 'momentAdapterFactory'
-        : 'adapterFactory'
+        : (options.dateAdapter === 'luxon' ? 'luxonAdapterFactory' : 'adapterFactory')
     } })`;
     const moduleCalendarSrc = 'angular-calendar';
 
@@ -151,6 +153,26 @@ function addModuleToImports(options: Schema): Rule {
           appModulePath,
           `;\n\nexport function momentAdapterFactory() {
   return adapterFactory(moment);
+}`
+        ) as InsertChange
+      );
+    }
+
+    if (options.dateAdapter === 'luxon') {
+      updates.push(
+        insertWildcardImport(
+          moduleSource as ts.SourceFile,
+          appModulePath,
+          'luxon',
+          'luxon'
+        ) as InsertChange
+      );
+      updates.push(
+        insertAfterImports(
+          moduleSource as ts.SourceFile,
+          appModulePath,
+          `;\n\nexport function luxonAdapterFactory() {
+  return adapterFactory();
 }`
         ) as InsertChange
       );

--- a/projects/angular-calendar/schematics/ng-add/schema.json
+++ b/projects/angular-calendar/schematics/ng-add/schema.json
@@ -8,7 +8,7 @@
       "description": "Which date adapter to use",
       "type": "string",
       "default": "date-fns",
-      "enum": ["moment", "date-fns"],
+      "enum": ["moment", "date-fns", "luxon"],
       "x-prompt": {
         "message": "What date adapter would you like to use?",
         "type": "list",
@@ -20,6 +20,10 @@
           {
             "value": "moment",
             "label": "moment          [ https://momentjs.com/ ]"
+          },
+          {
+            "value": "luxon",
+            "label": "luxon          [ https://moment.github.io/luxon/ ]"
           }
         ]
       }

--- a/projects/angular-calendar/schematics/ng-add/schema.ts
+++ b/projects/angular-calendar/schematics/ng-add/schema.ts
@@ -1,5 +1,5 @@
 export interface Schema {
-  dateAdapter: 'date-fns' | 'moment';
+  dateAdapter: 'date-fns' | 'moment' | 'luxon';
   module?: string;
   projectName?: string;
 }

--- a/projects/angular-calendar/schematics/ng-add/version-names.ts
+++ b/projects/angular-calendar/schematics/ng-add/version-names.ts
@@ -3,3 +3,4 @@ const packageJson = require('./package.json'); // eslint-disable-line  @typescri
 export const angularCalendarVersion = `^${packageJson.version}`;
 export const momentVersion = packageJson.devDependencies.moment;
 export const dateFnsVersion = packageJson.devDependencies['date-fns'];
+export const luxonVersion = packageJson.devDependencies.luxon;

--- a/projects/angular-calendar/src/date-adapters/luxon/index.ts
+++ b/projects/angular-calendar/src/date-adapters/luxon/index.ts
@@ -1,0 +1,55 @@
+import { adapterFactory as baseAdapterFactory } from 'calendar-utils/date-adapters/luxon';
+import { DateTime } from 'luxon';
+import { DateAdapter } from '../date-adapter';
+
+export function adapterFactory(): DateAdapter {
+  let coerceDateTime = (date: Date | number) => typeof date === 'number' ? DateTime.fromMillis(date) : DateTime.fromJSDate(date)
+
+  return {
+    ...baseAdapterFactory(),
+
+    addWeeks(date: Date | number, amount: number): Date {
+      return coerceDateTime(date).plus({ weeks: amount }).toJSDate();
+    },
+
+    addMonths(date: Date | number, amount: number): Date {
+      return coerceDateTime(date).plus({ months: amount }).toJSDate();
+    },
+
+    subDays(date: Date | number, amount: number): Date {
+      return coerceDateTime(date).minus({ days: amount }).toJSDate();
+    },
+
+    subWeeks(date: Date | number, amount: number): Date {
+      return coerceDateTime(date).minus({ weeks: amount }).toJSDate();
+    },
+
+    subMonths(date: Date | number, amount: number): Date {
+      return coerceDateTime(date).minus({ months: amount }).toJSDate();
+    },
+
+    getISOWeek(date: Date | number): number {
+      return coerceDateTime(date).weekNumber;
+    },
+
+    setDate(date: Date | number, dayOfMonth: number): Date {
+      return coerceDateTime(date).set({ day: dayOfMonth }).toJSDate();
+    },
+
+    setMonth(date: Date | number, month: number): Date {
+        return coerceDateTime(date).set({ month: month + 1 }).toJSDate();
+    },
+
+    setYear(date: Date | number, year: number): Date {
+        return coerceDateTime(date).set({ year: year }).toJSDate();
+    },
+
+    getDate(date: Date | number): number {
+      return coerceDateTime(date).day;
+    },
+
+    getYear(date: Date | number): number {
+        return coerceDateTime(date).year;
+    },
+  };
+}

--- a/projects/angular-calendar/util/date-adapter-package-luxon.json
+++ b/projects/angular-calendar/util/date-adapter-package-luxon.json
@@ -1,0 +1,5 @@
+{
+  "main": "./index.js",
+  "module": "../esm/luxon/index.js",
+  "typings": "./index.d.ts"
+}


### PR DESCRIPTION
I'm switching my project from moment to luxon so I needed luxon support in your (great!) calendar control.

I'm not very familiar with package building but hope I've adopted all the necessary files for a correct luxon support. By the way, since your `CalendarNativeDateFormatter` uses the `Intl` object (and I guess for that reason there is no `CalendarDateFnsDateFormatter`), why is there even a `CalendarMomentDateFormatter`? Any reason to use it at all?

Thank you for checking, probably some fixing ;) & deploying! :)