### PR TITLE
fix: fix scss deprecation warning to prepare for scss v3

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,14 @@ First install through npm:
 npm install --save angular-calendar date-fns
 ```
 
-Next include the CSS file in the global (not component scoped) styles of your app:
+Next include the CSS file in the global (not component scoped) styles of your app. For Angular 19.x, use the following to `use` the Angular Calendar:
+
+```
+/* angular-cli file: src/styles.css */
+@use "../node_modules/angular-calendar/css/angular-calendar.css";
+```
+
+For Angular versions <= 18.x, use the following to `import` the Angular Calendar:
 
 ```
 /* angular-cli file: src/styles.css */

--- a/README.md
+++ b/README.md
@@ -60,14 +60,7 @@ First install through npm:
 npm install --save angular-calendar date-fns
 ```
 
-Next include the CSS file in the global (not component scoped) styles of your app. For Angular 19.x, use the following to `use` the Angular Calendar:
-
-```
-/* angular-cli file: src/styles.css */
-@use "../node_modules/angular-calendar/css/angular-calendar.css";
-```
-
-For Angular versions <= 18.x, use the following to `import` the Angular Calendar:
+Next include the CSS file in the global (not component scoped) styles of your app:
 
 ```
 /* angular-cli file: src/styles.css */

--- a/projects/angular-calendar/src/angular-calendar.scss
+++ b/projects/angular-calendar/src/angular-calendar.scss
@@ -1,7 +1,7 @@
-@import 'modules/month/calendar-month-view/calendar-month-view';
-@import 'modules/week/calendar-week-view/calendar-week-view';
-@import 'modules/day/calendar-day-view/calendar-day-view';
-@import 'modules/common/calendar-tooltip/calendar-tooltip';
+@use 'modules/month/calendar-month-view/calendar-month-view';
+@use 'modules/week/calendar-week-view/calendar-week-view';
+@use 'modules/day/calendar-day-view/calendar-day-view';
+@use 'modules/common/calendar-tooltip/calendar-tooltip';
 
 @mixin cal-theme($overrides) {
   @include cal-month-view-theme($overrides);

--- a/projects/angular-calendar/src/modules/common/calendar-tooltip/calendar-tooltip.scss
+++ b/projects/angular-calendar/src/modules/common/calendar-tooltip/calendar-tooltip.scss
@@ -1,5 +1,5 @@
 @use 'sass:map';
-@import '../../../variables';
+@use '../../../variables';
 
 $cal-tooltip-vars: () !default;
 $cal-tooltip-vars: map.merge($cal-vars, $cal-tooltip-vars);

--- a/projects/angular-calendar/src/modules/month/calendar-month-view/calendar-month-view.scss
+++ b/projects/angular-calendar/src/modules/month/calendar-month-view/calendar-month-view.scss
@@ -1,6 +1,6 @@
 @use 'sass:map';
 @use 'sass:color';
-@import '../../../variables';
+@use '../../../variables';
 
 $cal-month-view-vars: () !default;
 $cal-month-view-vars: map.merge($cal-vars, $cal-month-view-vars);

--- a/projects/angular-calendar/src/modules/week/calendar-week-view/calendar-week-view.scss
+++ b/projects/angular-calendar/src/modules/week/calendar-week-view/calendar-week-view.scss
@@ -1,5 +1,5 @@
 @use 'sass:map';
-@import '../../../variables';
+@use '../../../variables';
 
 $cal-week-view-vars: () !default;
 $cal-week-view-vars: map.merge($cal-vars, $cal-week-view-vars);

--- a/projects/demos/app/demo-modules/context-menu/styles.scss
+++ b/projects/demos/app/demo-modules/context-menu/styles.scss
@@ -1,5 +1,5 @@
-@import '@angular/cdk/overlay-prebuilt.css';
-@import 'node_modules/@perfectmemory/ngx-contextmenu/src/assets/stylesheets/base';
+@use '@angular/cdk/overlay-prebuilt.css';
+@use 'node_modules/@perfectmemory/ngx-contextmenu/src/assets/stylesheets/base';
 
 .month-cell-fill-height {
   flex: 1;

--- a/projects/demos/app/demo-modules/dark-theme/styles.scss
+++ b/projects/demos/app/demo-modules/dark-theme/styles.scss
@@ -1,4 +1,4 @@
-@import '../../../../angular-calendar/src/angular-calendar';
+@use '../../../../angular-calendar/src/angular-calendar';
 
 .dark-theme {
   // First define some global color variables for your app, these are just for the demo, they can be anything you like

--- a/projects/demos/styles.scss
+++ b/projects/demos/styles.scss
@@ -1,8 +1,8 @@
-@import 'bootstrap/scss/bootstrap';
-@import '@fortawesome/fontawesome-free/css/all.css';
-@import 'highlight.js/styles/github.css';
-@import 'flatpickr/dist/flatpickr.css';
-@import '../angular-calendar/src/angular-calendar';
+@use 'bootstrap/scss/bootstrap';
+@use '@fortawesome/fontawesome-free/css/all.css';
+@use 'highlight.js/styles/github.css';
+@use 'flatpickr/dist/flatpickr.css';
+@use '../angular-calendar/src/angular-calendar';
 
 @media (min-width: 768px) {
   body {


### PR DESCRIPTION
Resolves issue #1762.

- Fixes deprecation warnings in Angular 19 builds: Sass @import rules are deprecated and will be removed in Dart Sass 3.0.0.