### PR TITLE
Disable Pointer-Events for TimeMarker

### DIFF
--- a/projects/angular-calendar/src/modules/day/calendar-day-view/calendar-day-view.scss
+++ b/projects/angular-calendar/src/modules/day/calendar-day-view/calendar-day-view.scss
@@ -20,6 +20,7 @@
   .cal-current-time-marker {
     margin-left: 70px;
     width: calc(100% - 70px);
+    pointer-events: none;
 
     [dir='rtl'] & {
       margin-left: initial;


### PR DESCRIPTION
Just a small patch / merging welcome :)

Disable the pointer-events for the time-marker (since the default implementation has no click handler and I don't see any point in it). Use-case is rare but right now clicking an appointment underneath the marker gets blocked by it.