### PR TITLE
feat: add resource-based week and day views

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,22 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+## [Unreleased]
+
+### Features
+
+* add resource-based week and day views for scheduling events by resource, with drag & drop support to reschedule and reassign them across resources ([#1736](https://github.com/mattlewis92/angular-calendar/issues/1736))
+  * add `CalendarResourceWeekViewComponent` and `CalendarResourceDayViewComponent`, standalone components rendering one row per resource and one column per day
+  * add a `resources` input (`CalendarResource[]`) and a `resources?` property on `CalendarEvent` to associate an event with one or more resources
+  * add `keepUnassignedEvents` / `unassignedRessourceName` inputs to control whether events with no resource are shown in a dedicated "Unassigned" row
+  * dragging an event horizontally changes its day only, keeping its time and assigned resources unchanged
+  * dragging an event vertically onto another resource's row reassigns it, replacing the source resource with the target resource
+  * dropping onto a resource the event is already assigned to cancels the move
+  * add a `mimicDragAcrossResources` input (default `true`) that mirrors the horizontal drag movement across every other resource row the same event is assigned to
+  * add `CalendarView.ResourceWeek` / `CalendarView.ResourceDay` enum members
+  * add a `resource-view` demo showing resource management, optional per-event resource assignment, drag & drop between resources, and a custom event template showing each event's start/end time
+  * export `CalendarResource`, `CalendarResourceIdType`, `getResourceWeekView` and the related `ResourceWeekView*` types from the public API
+
 ### [0.32.2](https://github.com/mattlewis92/angular-calendar/compare/v0.32.1...v0.32.2) (2026-04-08)
 
 

--- a/projects/angular-calendar/src/angular-calendar.scss
+++ b/projects/angular-calendar/src/angular-calendar.scss
@@ -1,10 +1,13 @@
 @use 'modules/month/calendar-month-view/calendar-month-view';
 @use 'modules/week/calendar-week-view/calendar-week-view';
 @use 'modules/day/calendar-day-view/calendar-day-view';
+@use 'modules/resource-week/calendar-resource-week-view/calendar-resource-week-view';
+@use 'modules/resource-day/calendar-resource-day-view/calendar-resource-day-view';
 @use 'modules/common/calendar-tooltip/calendar-tooltip';
 
 @mixin cal-theme($overrides) {
   @include calendar-month-view.cal-month-view-theme($overrides);
   @include calendar-week-view.cal-week-view-theme($overrides);
+  @include calendar-resource-week-view.cal-resource-week-view-theme($overrides);
   @include calendar-tooltip.cal-tooltip-theme($overrides);
 }

--- a/projects/angular-calendar/src/modules/calendar.module.ts
+++ b/projects/angular-calendar/src/modules/calendar.module.ts
@@ -10,11 +10,15 @@ import {
 import { CalendarMonthModule } from './month/calendar-month.module';
 import { CalendarWeekModule } from './week/calendar-week.module';
 import { CalendarDayModule } from './day/calendar-day.module';
+import { CalendarResourceWeekModule } from './resource-week/calendar-resource-week.module';
+import { CalendarResourceDayModule } from './resource-day/calendar-resource-day.module';
 
 export * from './common/calendar-common.module';
 export * from './month/calendar-month.module';
 export * from './week/calendar-week.module';
 export * from './day/calendar-day.module';
+export * from './resource-week/calendar-resource-week.module';
+export * from './resource-day/calendar-resource-day.module';
 
 /**
  * The main module of this library. Example usage:
@@ -56,12 +60,16 @@ export * from './day/calendar-day.module';
     CalendarMonthModule,
     CalendarWeekModule,
     CalendarDayModule,
+    CalendarResourceWeekModule,
+    CalendarResourceDayModule,
   ],
   exports: [
     CalendarCommonModule,
     CalendarMonthModule,
     CalendarWeekModule,
     CalendarDayModule,
+    CalendarResourceWeekModule,
+    CalendarResourceDayModule,
   ],
 })
 export class CalendarModule {

--- a/projects/angular-calendar/src/modules/common/calendar-common.module.ts
+++ b/projects/angular-calendar/src/modules/common/calendar-common.module.ts
@@ -55,6 +55,11 @@ export {
   ViewPeriod as CalendarViewPeriod,
 } from 'calendar-utils';
 
+export {
+  CalendarResource,
+  CalendarResourceIdType,
+} from './calendar-resource/calendar-resource.interface';
+
 /**
  * Import this module to if you're just using a singular view and want to save on bundle size. Example usage:
  *

--- a/projects/angular-calendar/src/modules/common/calendar-resource/calendar-resource.interface.ts
+++ b/projects/angular-calendar/src/modules/common/calendar-resource/calendar-resource.interface.ts
@@ -1,0 +1,89 @@
+import { CalendarEvent } from 'calendar-utils';
+
+export type CalendarResourceIdType = string | number;
+
+export interface CalendarResource<CalendarResourceMetaType = any> {
+  id: CalendarResourceIdType;
+  name: string;
+  meta?: CalendarResourceMetaType;
+}
+
+export interface ResourcesMaxRowNumber<CalendarResourceMetaType = any> {
+  count: number;
+  resource: CalendarResource<CalendarResourceMetaType>;
+  top: number;
+}
+
+export interface ResourcesMaxRowsNumber<CalendarResourceMetaType = any> {
+  [index: number]: ResourcesMaxRowNumber<CalendarResourceMetaType>;
+}
+
+export interface ResourceWeekViewRowEvent<EventMetaType = any> {
+  event: CalendarEvent<EventMetaType>;
+  height: number;
+  width: number;
+  top: number;
+  left: number;
+}
+
+export interface ResourceWeekViewRowEventContainer<
+  EventMetaType = any,
+  ResourceMetaType = any,
+> {
+  resource: CalendarResource<ResourceMetaType>;
+  resourceCurrentDayEventNumber: number;
+  events: ResourceWeekViewRowEvent<EventMetaType>[];
+}
+
+export interface ResourceWeekViewRowColumn<
+  EventMetaType = any,
+  ResourceMetaType = any,
+> {
+  date: Date;
+  eventsGroupedByResource: ResourceWeekViewRowEventContainer<
+    EventMetaType,
+    ResourceMetaType
+  >[];
+}
+
+export interface ResourceWeekViewRowSegment {
+  isStart?: boolean;
+  date?: Date;
+  cssClass?: string;
+}
+
+export interface ResourceWeekView<EventMetaType = any, ResourceMetaType = any> {
+  period: {
+    start: Date;
+    end: Date;
+    events: CalendarEvent<EventMetaType>[];
+  };
+  rowColumns: ResourceWeekViewRowColumn<EventMetaType, ResourceMetaType>[];
+  resourcesMaxRowsNumber: ResourcesMaxRowsNumber;
+}
+
+export interface GetResourceWeekViewArgs {
+  events?: CalendarEvent[];
+  resources: CalendarResource[];
+  viewDate: Date;
+  weekStartsOn: number;
+  excluded?: number[];
+  precision?: 'minutes' | 'days';
+  absolutePositionedEvents?: boolean;
+  hourSegments?: number;
+  dayStart: { hour: number; minute: number };
+  dayEnd: { hour: number; minute: number };
+  weekendDays?: number[];
+  segmentHeight: number;
+  viewStart?: Date;
+  viewEnd?: Date;
+  minimumEventHeight?: number;
+  keepUnassignedEvents?: boolean;
+  unassignedRessourceName?: string;
+}
+
+declare module 'calendar-utils' {
+  interface CalendarEvent<MetaType = any> {
+    resources?: CalendarResource[];
+  }
+}

--- a/projects/angular-calendar/src/modules/common/calendar-resource/get-resource-week-view.ts
+++ b/projects/angular-calendar/src/modules/common/calendar-resource/get-resource-week-view.ts
@@ -1,0 +1,254 @@
+import {
+  CalendarEvent,
+  getEventsInPeriod,
+  getWeekViewHeader,
+} from 'calendar-utils';
+import { DateAdapter } from '../../../date-adapters/date-adapter';
+import {
+  CalendarResource,
+  GetResourceWeekViewArgs,
+  ResourceWeekView,
+  ResourceWeekViewRowColumn,
+  ResourcesMaxRowNumber,
+  ResourcesMaxRowsNumber,
+} from './calendar-resource.interface';
+
+function sanitiseHours(hours: number): number {
+  return Math.max(Math.min(23, hours), 0);
+}
+
+function sanitiseMinutes(minutes: number): number {
+  return Math.max(Math.min(59, minutes), 0);
+}
+
+function getResourceDayEvents(
+  dateAdapter: DateAdapter,
+  events: CalendarEvent[],
+  viewDate: Date,
+  dayStart: { hour: number; minute: number },
+  dayEnd: { hour: number; minute: number },
+): CalendarEvent[] {
+  const startOfView = dateAdapter.setMinutes(
+    dateAdapter.setHours(
+      dateAdapter.startOfDay(viewDate),
+      sanitiseHours(dayStart.hour),
+    ),
+    sanitiseMinutes(dayStart.minute),
+  );
+  const endOfView = dateAdapter.setMinutes(
+    dateAdapter.setHours(
+      dateAdapter.startOfMinute(dateAdapter.endOfDay(viewDate)),
+      sanitiseHours(dayEnd.hour),
+    ),
+    sanitiseMinutes(dayEnd.minute),
+  );
+  endOfView.setSeconds(59, 999);
+
+  return getEventsInPeriod(dateAdapter, {
+    events,
+    periodStart: startOfView,
+    periodEnd: endOfView,
+  }).sort((eventA, eventB) => eventA.start.valueOf() - eventB.start.valueOf());
+}
+
+function getResourceWeekViewRowColumns(
+  dateAdapter: DateAdapter,
+  {
+    events,
+    resources,
+    viewDate,
+    dayStart,
+    dayEnd,
+    weekStartsOn,
+    excluded,
+    weekendDays,
+    segmentHeight,
+    viewStart,
+    viewEnd,
+    keepUnassignedEvents,
+    unassignedRessourceName,
+  }: {
+    events: CalendarEvent[];
+    resources: CalendarResource[];
+    viewDate: Date;
+    dayStart: { hour: number; minute: number };
+    dayEnd: { hour: number; minute: number };
+    weekStartsOn: number;
+    excluded: number[];
+    weekendDays?: number[];
+    segmentHeight: number;
+    viewStart: Date;
+    viewEnd: Date;
+    keepUnassignedEvents: boolean;
+    unassignedRessourceName: string;
+  },
+  setResourcesMaxRowsNumber: (result: ResourcesMaxRowsNumber) => void,
+): ResourceWeekViewRowColumn[] {
+  const weekDays = getWeekViewHeader(dateAdapter, {
+    viewDate,
+    weekStartsOn,
+    excluded,
+    weekendDays,
+    viewStart,
+    viewEnd,
+  });
+
+  const resourcesMaxRowsNumber: ResourcesMaxRowNumber[] = [];
+
+  return weekDays.map((day) => {
+    const dayEvents = getResourceDayEvents(
+      dateAdapter,
+      events,
+      day.date,
+      dayStart,
+      dayEnd,
+    );
+
+    const mappedEvents = (calendarEvents: CalendarEvent[]) =>
+      calendarEvents.map((event, index) => ({
+        event,
+        height: segmentHeight,
+        left: 0,
+        width: 100,
+        top: index * segmentHeight,
+      }));
+
+    const accumulatePreviousContainerCountsByIndex = (
+      currentContainerIndex: number,
+    ) => {
+      let count = 0;
+      for (let k = 0; k < currentContainerIndex; k++) {
+        count += resourcesMaxRowsNumber[k].count;
+      }
+      return count;
+    };
+
+    const unknownResource = {
+      id: undefined,
+      name: unassignedRessourceName,
+    } as unknown as CalendarResource;
+    const combinedResourceList = keepUnassignedEvents
+      ? [...resources, unknownResource]
+      : resources;
+
+    const eventsGroupedByResource = combinedResourceList.map(
+      (resource, resourceIndex) => {
+        const filterClosure =
+          resource.id !== undefined
+            ? (event: CalendarEvent) =>
+                event.resources?.some(
+                  (oneResource) => oneResource.id === resource.id,
+                )
+            : (event: CalendarEvent) =>
+                !event.resources || event.resources.length === 0;
+
+        const filteredEvents = dayEvents.filter(filterClosure);
+
+        const resourcesMaxRowsNumberItem =
+          resourcesMaxRowsNumber[resourceIndex];
+        const isCountGreaterThanPrevious =
+          !!resourcesMaxRowsNumberItem &&
+          resourcesMaxRowsNumberItem.count >= filteredEvents.length;
+        const newCount = isCountGreaterThanPrevious
+          ? resourcesMaxRowsNumberItem.count
+          : filteredEvents.length;
+
+        resourcesMaxRowsNumber[resourceIndex] = {
+          ...resourcesMaxRowsNumberItem,
+          count: newCount + (resourceIndex >= 0 && newCount === 0 ? 1 : 0),
+          resource,
+          top:
+            accumulatePreviousContainerCountsByIndex(resourceIndex) *
+            segmentHeight,
+        };
+
+        return {
+          resource,
+          resourceCurrentDayEventNumber: filteredEvents.length,
+          events: mappedEvents(filteredEvents),
+        };
+      },
+    );
+
+    setResourcesMaxRowsNumber(
+      resourcesMaxRowsNumber as unknown as ResourcesMaxRowsNumber,
+    );
+
+    return {
+      date: day.date,
+      eventsGroupedByResource,
+    };
+  });
+}
+
+export function getResourceWeekView(
+  dateAdapter: DateAdapter,
+  {
+    events = [],
+    resources = [],
+    viewDate,
+    weekStartsOn,
+    excluded = [],
+    hourSegments,
+    dayStart,
+    dayEnd,
+    weekendDays,
+    segmentHeight,
+    viewStart = dateAdapter.startOfWeek(viewDate, { weekStartsOn }),
+    viewEnd = dateAdapter.endOfWeek(viewDate, { weekStartsOn }),
+    keepUnassignedEvents = true,
+    unassignedRessourceName = 'Unassigned',
+  }: GetResourceWeekViewArgs,
+): ResourceWeekView {
+  viewStart = dateAdapter.startOfDay(viewStart);
+  viewEnd = dateAdapter.endOfDay(viewEnd);
+
+  const eventsInPeriod = getEventsInPeriod(dateAdapter, {
+    events,
+    periodStart: viewStart,
+    periodEnd: viewEnd,
+  });
+
+  const header = getWeekViewHeader(dateAdapter, {
+    viewDate,
+    weekStartsOn,
+    excluded,
+    weekendDays,
+    viewStart,
+    viewEnd,
+  });
+
+  let resourcesMaxRowsNumber: ResourcesMaxRowsNumber = {};
+
+  const rowColumns = getResourceWeekViewRowColumns(
+    dateAdapter,
+    {
+      events,
+      resources,
+      viewDate,
+      dayStart,
+      dayEnd,
+      weekStartsOn,
+      excluded,
+      weekendDays,
+      segmentHeight,
+      viewStart,
+      viewEnd,
+      keepUnassignedEvents,
+      unassignedRessourceName,
+    },
+    (result) => {
+      resourcesMaxRowsNumber = result;
+    },
+  );
+
+  return {
+    period: {
+      events: eventsInPeriod,
+      start: header[0].date,
+      end: dateAdapter.endOfDay(header[header.length - 1].date),
+    },
+    rowColumns,
+    resourcesMaxRowsNumber,
+  };
+}

--- a/projects/angular-calendar/src/modules/common/calendar-utils/calendar-utils.provider.ts
+++ b/projects/angular-calendar/src/modules/common/calendar-utils/calendar-utils.provider.ts
@@ -11,6 +11,11 @@ import {
   getWeekView,
 } from 'calendar-utils';
 import { DateAdapter } from '../../../date-adapters/date-adapter';
+import { getResourceWeekView } from '../calendar-resource/get-resource-week-view';
+import {
+  ResourceWeekView,
+  GetResourceWeekViewArgs,
+} from '../calendar-resource/calendar-resource.interface';
 
 @Injectable()
 export class CalendarUtils {
@@ -26,5 +31,9 @@ export class CalendarUtils {
 
   getWeekView(args: GetWeekViewArgs): WeekView {
     return getWeekView(this.dateAdapter, args);
+  }
+
+  getResourceWeekView(args: GetResourceWeekViewArgs): ResourceWeekView {
+    return getResourceWeekView(this.dateAdapter, args);
   }
 }

--- a/projects/angular-calendar/src/modules/common/calendar-view/calendar-view.enum.ts
+++ b/projects/angular-calendar/src/modules/common/calendar-view/calendar-view.enum.ts
@@ -2,4 +2,6 @@ export enum CalendarView {
   Month = 'month',
   Week = 'week',
   Day = 'day',
+  ResourceWeek = 'resourceWeek',
+  ResourceDay = 'resourceDay',
 }

--- a/projects/angular-calendar/src/modules/resource-day/calendar-resource-day-view/calendar-resource-day-view.component.ts
+++ b/projects/angular-calendar/src/modules/resource-day/calendar-resource-day-view/calendar-resource-day-view.component.ts
@@ -1,0 +1,257 @@
+import {
+  Component,
+  Input,
+  Output,
+  EventEmitter,
+  TemplateRef,
+} from '@angular/core';
+import { CalendarEvent } from 'calendar-utils';
+import { CalendarResource } from '../../common/calendar-resource/calendar-resource.interface';
+import { Subject } from 'rxjs';
+import { CalendarEventTimesChangedEvent } from '../../common/calendar-event-times-changed-event/calendar-event-times-changed-event.interface';
+import { PlacementArray } from 'positioning';
+import { CalendarResourceWeekViewBeforeRenderEvent } from '../../resource-week/calendar-resource-week.module';
+import {
+  CalendarResourceEventTimesChangedEvent,
+  CalendarResourceWeekViewComponent,
+} from '../../resource-week/calendar-resource-week-view/calendar-resource-week-view.component';
+
+export type CalendarResourceDayViewBeforeRenderEvent =
+  CalendarResourceWeekViewBeforeRenderEvent;
+
+/**
+ * Shows all events on a given day, grouped by resource. Example usage:
+ *
+ * ```typescript
+ * <mwl-calendar-resource-day-view
+ *  [viewDate]="viewDate"
+ *  [events]="events"
+ *  [resources]="resources">
+ * </mwl-calendar-resource-day-view>
+ * ```
+ */
+@Component({
+  selector: 'mwl-calendar-resource-day-view',
+  template: `
+    <mwl-calendar-resource-week-view
+      class="cal-resource-day-view"
+      [daysInWeek]="1"
+      [viewDate]="viewDate"
+      [events]="events"
+      [resources]="resources"
+      [hourSegments]="hourSegments"
+      [hourDuration]="hourDuration"
+      [hourSegmentHeight]="hourSegmentHeight"
+      [minimumEventHeight]="minimumEventHeight"
+      [dayStartHour]="dayStartHour"
+      [dayStartMinute]="dayStartMinute"
+      [dayEndHour]="dayEndHour"
+      [dayEndMinute]="dayEndMinute"
+      [refresh]="refresh"
+      [locale]="locale"
+      [eventSnapSize]="eventSnapSize"
+      [tooltipPlacement]="tooltipPlacement"
+      [tooltipTemplate]="tooltipTemplate"
+      [tooltipAppendToBody]="tooltipAppendToBody"
+      [tooltipDelay]="tooltipDelay"
+      [hourSegmentTemplate]="hourSegmentTemplate"
+      [eventTemplate]="eventTemplate"
+      [eventTitleTemplate]="eventTitleTemplate"
+      [eventActionsTemplate]="eventActionsTemplate"
+      [snapDraggedEvents]="snapDraggedEvents"
+      [allDayEventsLabelTemplate]="allDayEventsLabelTemplate"
+      [currentTimeMarkerTemplate]="currentTimeMarkerTemplate"
+      [validateEventTimesChanged]="validateEventTimesChanged"
+      [keepUnassignedEvents]="keepUnassignedEvents"
+      [unassignedRessourceName]="unassignedRessourceName"
+      [mimicDragAcrossResources]="mimicDragAcrossResources"
+      (eventClicked)="eventClicked.emit($event)"
+      (hourSegmentClicked)="hourSegmentClicked.emit($event)"
+      (eventTimesChanged)="eventTimesChanged.emit($event)"
+      (beforeViewRender)="beforeViewRender.emit($event)"
+    />
+  `,
+  imports: [CalendarResourceWeekViewComponent],
+})
+export class CalendarResourceDayViewComponent {
+  /**
+   * The current view date
+   */
+  @Input() viewDate: Date;
+
+  /**
+   * An array of events to display on view
+   * The schema is available here: https://github.com/mattlewis92/calendar-utils/blob/c51689985f59a271940e30bc4e2c4e1fee3fcb5c/src/calendarUtils.ts#L49-L63
+   */
+  @Input() events: CalendarEvent[] = [];
+
+  /**
+   * An array of resources to display on view
+   */
+  @Input() resources: CalendarResource[] = [];
+
+  /**
+   * The number of segments in an hour. Must divide equally into 60.
+   */
+  @Input() hourSegments: number = 2;
+
+  /**
+   * The height in pixels of each hour segment
+   */
+  @Input() hourSegmentHeight: number = 50;
+
+  /**
+   * The duration of each segment group in minutes
+   */
+  @Input() hourDuration: number;
+
+  /**
+   * The minimum height in pixels of each event
+   */
+  @Input() minimumEventHeight: number = 50;
+
+  /**
+   * The day start hours in 24 hour time. Must be 0-23
+   */
+  @Input() dayStartHour: number = 0;
+
+  /**
+   * The day start minutes. Must be 0-59
+   */
+  @Input() dayStartMinute: number = 0;
+
+  /**
+   * The day end hours in 24 hour time. Must be 0-23
+   */
+  @Input() dayEndHour: number = 23;
+
+  /**
+   * The day end minutes. Must be 0-59
+   */
+  @Input() dayEndMinute: number = 59;
+
+  /**
+   * An observable that when emitted on will re-render the current view
+   */
+  @Input() refresh: Subject<any>;
+
+  /**
+   * The locale used to format dates
+   */
+  @Input() locale: string;
+
+  /**
+   * The grid size to snap resizing and dragging of events to
+   */
+  @Input() eventSnapSize: number;
+
+  /**
+   * The placement of the event tooltip
+   */
+  @Input() tooltipPlacement: PlacementArray = 'auto';
+
+  /**
+   * A custom template to use for the event tooltips
+   */
+  @Input() tooltipTemplate: TemplateRef<any>;
+
+  /**
+   * Whether to append tooltips to the body or next to the trigger element
+   */
+  @Input() tooltipAppendToBody: boolean = true;
+
+  /**
+   * The delay in milliseconds before the tooltip should be displayed. If not provided the tooltip
+   * will be displayed immediately.
+   */
+  @Input() tooltipDelay: number | null = null;
+
+  /**
+   * A custom template to use to replace the hour segment
+   */
+  @Input() hourSegmentTemplate: TemplateRef<any>;
+
+  /**
+   * A custom template to use for day view events
+   */
+  @Input() eventTemplate: TemplateRef<any>;
+
+  /**
+   * A custom template to use for event titles
+   */
+  @Input() eventTitleTemplate: TemplateRef<any>;
+
+  /**
+   * A custom template to use for event actions
+   */
+  @Input() eventActionsTemplate: TemplateRef<any>;
+
+  /**
+   * Whether to snap events to a grid when dragging
+   */
+  @Input() snapDraggedEvents: boolean = true;
+
+  /**
+   * A custom template to use for the all day events label text
+   */
+  @Input() allDayEventsLabelTemplate: TemplateRef<any>;
+
+  /**
+   * A custom template to use for the current time marker
+   */
+  @Input() currentTimeMarkerTemplate: TemplateRef<any>;
+
+  /**
+   * Should we display events without assigned resources
+   */
+  @Input() keepUnassignedEvents: boolean = true;
+
+  /**
+   * Name to display unassigned resource. This apply only if keepUnassignedEvents is equal to true
+   */
+  @Input() unassignedRessourceName: string = 'Unassigned';
+
+  /**
+   * When dragging an event assigned to several resources, mimic the horizontal movement on
+   * that same event's tile in every other resource row it's also assigned to
+   */
+  @Input() mimicDragAcrossResources: boolean = true;
+
+  /**
+   * Allow you to customise where events can be dragged and resized to.
+   * Return true to allow dragging and resizing to the new location, or false to prevent it
+   */
+  @Input() validateEventTimesChanged: (
+    event: CalendarEventTimesChangedEvent,
+  ) => boolean;
+
+  /**
+   * Called when an event title is clicked
+   */
+  @Output() eventClicked = new EventEmitter<{
+    event: CalendarEvent;
+    sourceEvent: MouseEvent | KeyboardEvent;
+  }>();
+
+  /**
+   * Called when an hour segment is clicked
+   */
+  @Output() hourSegmentClicked = new EventEmitter<{
+    date: Date;
+    sourceEvent: MouseEvent;
+  }>();
+
+  /**
+   * Called when an event is dragged and dropped.
+   * If dropped onto another resource's row, `resources` reflects the event's new resources
+   */
+  @Output() eventTimesChanged =
+    new EventEmitter<CalendarResourceEventTimesChangedEvent>();
+
+  /**
+   * An output that will be called before the view is rendered for the current day.
+   * If you add the `cssClass` property to an hour grid segment it will add that class to the hour segment in the template
+   */
+  @Output() beforeViewRender =
+    new EventEmitter<CalendarResourceDayViewBeforeRenderEvent>();
+}

--- a/projects/angular-calendar/src/modules/resource-day/calendar-resource-day-view/calendar-resource-day-view.scss
+++ b/projects/angular-calendar/src/modules/resource-day/calendar-resource-day-view/calendar-resource-day-view.scss
@@ -1,0 +1,12 @@
+.cal-resource-day-view {
+  /* stylelint-disable-next-line selector-type-no-unknown */
+  mwl-calendar-resource-week-view-header {
+    display: none;
+  }
+
+  .cal-events-container {
+    [dir='rtl'] & {
+      margin-left: initial;
+    }
+  }
+}

--- a/projects/angular-calendar/src/modules/resource-day/calendar-resource-day.module.ts
+++ b/projects/angular-calendar/src/modules/resource-day/calendar-resource-day.module.ts
@@ -1,0 +1,22 @@
+import { NgModule } from '@angular/core';
+import { CalendarResourceDayViewComponent } from './calendar-resource-day-view/calendar-resource-day-view.component';
+import { CalendarCommonModule } from '../common/calendar-common.module';
+import { CalendarResourceWeekModule } from '../resource-week/calendar-resource-week.module';
+
+export {
+  CalendarResourceDayViewComponent,
+  CalendarResourceDayViewBeforeRenderEvent,
+} from './calendar-resource-day-view/calendar-resource-day-view.component';
+
+/**
+ * @deprecated import the standalone component `CalendarResourceDayViewComponent` instead
+ */
+@NgModule({
+  imports: [
+    CalendarCommonModule,
+    CalendarResourceWeekModule,
+    CalendarResourceDayViewComponent,
+  ],
+  exports: [CalendarResourceDayViewComponent],
+})
+export class CalendarResourceDayModule {}

--- a/projects/angular-calendar/src/modules/resource-week/calendar-resource-week-view/calendar-resource-week-view-event/calendar-resource-week-view-event.component.ts
+++ b/projects/angular-calendar/src/modules/resource-week/calendar-resource-week-view/calendar-resource-week-view-event/calendar-resource-week-view-event.component.ts
@@ -1,0 +1,133 @@
+import {
+  Component,
+  Input,
+  Output,
+  EventEmitter,
+  TemplateRef,
+} from '@angular/core';
+import {
+  ResourceWeekViewRowEvent,
+  ResourceWeekViewRowColumn,
+} from '../../../common/calendar-resource/calendar-resource.interface';
+import { PlacementArray } from 'positioning';
+import { NgStyle, NgTemplateOutlet } from '@angular/common';
+import { CalendarTooltipDirective } from '../../../common/calendar-tooltip/calendar-tooltip.directive';
+import { ClickDirective } from '../../../common/click/click.directive';
+import { KeydownEnterDirective } from '../../../common/keydown-enter/keydown-enter.directive';
+import { CalendarEventActionsComponent } from '../../../common/calendar-event-actions/calendar-event-actions.component';
+import { CalendarEventTitleComponent } from '../../../common/calendar-event-title/calendar-event-title.component';
+import { CalendarEventTitlePipe } from '../../../common/calendar-event-title/calendar-event-title.pipe';
+import { CalendarA11yPipe } from '../../../common/calendar-a11y/calendar-a11y.pipe';
+
+@Component({
+  selector: 'mwl-calendar-resource-week-view-event',
+  template: `
+    <ng-template
+      #defaultTemplate
+      let-weekEvent="weekEvent"
+      let-tooltipPlacement="tooltipPlacement"
+      let-eventClicked="eventClicked"
+      let-tooltipTemplate="tooltipTemplate"
+      let-tooltipAppendToBody="tooltipAppendToBody"
+      let-tooltipDisabled="tooltipDisabled"
+      let-tooltipDelay="tooltipDelay"
+      let-column="column"
+      let-daysInWeek="daysInWeek"
+    >
+      <div
+        class="cal-event"
+        [ngStyle]="{
+          color: weekEvent.event.color?.secondaryText,
+          backgroundColor: weekEvent.event.color?.secondary,
+          borderColor: weekEvent.event.color?.primary,
+        }"
+        [mwlCalendarTooltip]="
+          !tooltipDisabled
+            ? (weekEvent.event.title
+              | calendarEventTitle
+                : (daysInWeek === 1 ? 'dayTooltip' : 'weekTooltip')
+                : weekEvent.tempEvent || weekEvent.event)
+            : ''
+        "
+        [tooltipPlacement]="tooltipPlacement"
+        [tooltipEvent]="weekEvent.tempEvent || weekEvent.event"
+        [tooltipTemplate]="tooltipTemplate"
+        [tooltipAppendToBody]="tooltipAppendToBody"
+        [tooltipDelay]="tooltipDelay"
+        (mwlClick)="eventClicked.emit({ sourceEvent: $event })"
+        (mwlKeydownEnter)="eventClicked.emit({ sourceEvent: $event })"
+        tabindex="0"
+        role="application"
+        [attr.aria-label]="
+          { event: weekEvent.tempEvent || weekEvent.event, locale: locale }
+            | calendarA11y: 'eventDescription'
+        "
+      >
+        <mwl-calendar-event-actions
+          [event]="weekEvent.tempEvent || weekEvent.event"
+          [customTemplate]="eventActionsTemplate"
+        />
+        &ngsp;
+        <mwl-calendar-event-title
+          [event]="weekEvent.tempEvent || weekEvent.event"
+          [customTemplate]="eventTitleTemplate"
+          [view]="daysInWeek === 1 ? 'day' : 'week'"
+        />
+      </div>
+    </ng-template>
+    <ng-template
+      [ngTemplateOutlet]="customTemplate || defaultTemplate"
+      [ngTemplateOutletContext]="{
+        weekEvent: weekEvent,
+        tooltipPlacement: tooltipPlacement,
+        eventClicked: eventClicked,
+        tooltipTemplate: tooltipTemplate,
+        tooltipAppendToBody: tooltipAppendToBody,
+        tooltipDisabled: tooltipDisabled,
+        tooltipDelay: tooltipDelay,
+        column: column,
+        daysInWeek: daysInWeek,
+      }"
+    />
+  `,
+  imports: [
+    NgStyle,
+    CalendarTooltipDirective,
+    ClickDirective,
+    KeydownEnterDirective,
+    CalendarEventActionsComponent,
+    CalendarEventTitleComponent,
+    NgTemplateOutlet,
+    CalendarEventTitlePipe,
+    CalendarA11yPipe,
+  ],
+})
+export class CalendarResourceWeekViewEventComponent {
+  @Input() locale: string;
+
+  @Input() weekEvent: ResourceWeekViewRowEvent;
+
+  @Input() tooltipPlacement: PlacementArray;
+
+  @Input() tooltipAppendToBody: boolean;
+
+  @Input() tooltipDisabled: boolean;
+
+  @Input() tooltipDelay: number | null;
+
+  @Input() customTemplate: TemplateRef<any>;
+
+  @Input() eventTitleTemplate: TemplateRef<any>;
+
+  @Input() eventActionsTemplate: TemplateRef<any>;
+
+  @Input() tooltipTemplate: TemplateRef<any>;
+
+  @Input() column: ResourceWeekViewRowColumn;
+
+  @Input() daysInWeek: number;
+
+  @Output() eventClicked = new EventEmitter<{
+    sourceEvent: MouseEvent | KeyboardEvent;
+  }>();
+}

--- a/projects/angular-calendar/src/modules/resource-week/calendar-resource-week-view/calendar-resource-week-view-header/calendar-resource-week-view-header.component.ts
+++ b/projects/angular-calendar/src/modules/resource-week/calendar-resource-week-view/calendar-resource-week-view-header/calendar-resource-week-view-header.component.ts
@@ -1,0 +1,95 @@
+import {
+  Component,
+  Input,
+  Output,
+  EventEmitter,
+  TemplateRef,
+} from '@angular/core';
+import { CalendarEvent, WeekDay } from 'calendar-utils';
+import { DroppableDirective } from 'angular-draggable-droppable';
+import { NgClass, NgTemplateOutlet } from '@angular/common';
+import { ClickDirective } from '../../../common/click/click.directive';
+import { CalendarDatePipe } from '../../../common/calendar-date/calendar-date.pipe';
+
+@Component({
+  selector: 'mwl-calendar-resource-week-view-header',
+  template: `
+    <ng-template
+      #defaultTemplate
+      let-days="days"
+      let-locale="locale"
+      let-dayHeaderClicked="dayHeaderClicked"
+      let-eventDropped="eventDropped"
+      let-dragEnter="dragEnter"
+    >
+      <div class="cal-day-headers" role="row">
+        @for (day of days; track day.date.toISOString()) {
+          <div
+            class="cal-header"
+            [class.cal-past]="day.isPast"
+            [class.cal-today]="day.isToday"
+            [class.cal-future]="day.isFuture"
+            [class.cal-weekend]="day.isWeekend"
+            [ngClass]="day.cssClass"
+            (mwlClick)="
+              dayHeaderClicked.emit({ day: day, sourceEvent: $event })
+            "
+            mwlDroppable
+            dragOverClass="cal-drag-over"
+            (drop)="
+              eventDropped.emit({
+                event: $event.dropData.event,
+                newStart: day.date,
+              })
+            "
+            (dragEnter)="dragEnter.emit({ date: day.date })"
+            tabindex="0"
+            role="columnheader"
+          >
+            <b>{{ day.date | calendarDate: 'weekViewColumnHeader' : locale }}</b
+            ><br />
+            <span>{{
+              day.date | calendarDate: 'weekViewColumnSubHeader' : locale
+            }}</span>
+          </div>
+        }
+      </div>
+    </ng-template>
+    <ng-template
+      [ngTemplateOutlet]="customTemplate || defaultTemplate"
+      [ngTemplateOutletContext]="{
+        days: days,
+        locale: locale,
+        dayHeaderClicked: dayHeaderClicked,
+        eventDropped: eventDropped,
+        dragEnter: dragEnter,
+      }"
+    />
+  `,
+  imports: [
+    DroppableDirective,
+    NgClass,
+    ClickDirective,
+    NgTemplateOutlet,
+    CalendarDatePipe,
+  ],
+})
+export class CalendarResourceWeekViewHeaderComponent {
+  @Input() days: WeekDay[];
+
+  @Input() locale: string;
+
+  @Input() customTemplate: TemplateRef<any>;
+
+  @Output() dayHeaderClicked = new EventEmitter<{
+    day: WeekDay;
+    sourceEvent: MouseEvent;
+  }>();
+
+  @Output() eventDropped = new EventEmitter<{
+    event: CalendarEvent;
+    newStart: Date;
+  }>();
+
+  @Output() dragEnter = new EventEmitter<{ date: Date }>();
+}

--- a/projects/angular-calendar/src/modules/resource-week/calendar-resource-week-view/calendar-resource-week-view-row-segment/calendar-resource-week-view-row-segment.component.ts
+++ b/projects/angular-calendar/src/modules/resource-week/calendar-resource-week-view/calendar-resource-week-view-row-segment/calendar-resource-week-view-row-segment.component.ts
@@ -1,0 +1,57 @@
+import { Component, Input, TemplateRef } from '@angular/core';
+import { ResourceWeekViewRowSegment } from '../../../common/calendar-resource/calendar-resource.interface';
+import { NgClass, NgTemplateOutlet } from '@angular/common';
+import { CalendarA11yPipe } from '../../../common/calendar-a11y/calendar-a11y.pipe';
+
+@Component({
+  selector: 'mwl-calendar-resource-week-view-row-segment',
+  template: `
+    <ng-template
+      #defaultTemplate
+      let-segment="segment"
+      let-segmentHeight="segmentHeight"
+      let-resourceLabel="resourceLabel"
+      let-daysInWeek="daysInWeek"
+    >
+      <div
+        [attr.aria-hidden]="
+          {}
+            | calendarA11y
+              : (daysInWeek === 1
+                  ? 'hideDayHourSegment'
+                  : 'hideWeekHourSegment')
+        "
+        class="cal-hour-segment"
+        [style.height.px]="segmentHeight"
+        [ngClass]="segment?.cssClass"
+      >
+        @if (resourceLabel) {
+          <div class="cal-time">
+            {{ resourceLabel }}
+          </div>
+        }
+      </div>
+    </ng-template>
+    <ng-template
+      [ngTemplateOutlet]="customTemplate || defaultTemplate"
+      [ngTemplateOutletContext]="{
+        segment: segment,
+        segmentHeight: segmentHeight,
+        resourceLabel: resourceLabel,
+        daysInWeek: daysInWeek,
+      }"
+    />
+  `,
+  imports: [NgClass, NgTemplateOutlet, CalendarA11yPipe],
+})
+export class CalendarResourceWeekViewRowSegmentComponent {
+  @Input() segment: ResourceWeekViewRowSegment;
+
+  @Input() segmentHeight: number;
+
+  @Input() resourceLabel: string;
+
+  @Input() daysInWeek: number;
+
+  @Input() customTemplate: TemplateRef<any>;
+}

--- a/projects/angular-calendar/src/modules/resource-week/calendar-resource-week-view/calendar-resource-week-view.component.ts
+++ b/projects/angular-calendar/src/modules/resource-week/calendar-resource-week-view/calendar-resource-week-view.component.ts
@@ -1,0 +1,807 @@
+import {
+  Component,
+  Input,
+  Output,
+  EventEmitter,
+  ChangeDetectorRef,
+  OnChanges,
+  OnInit,
+  OnDestroy,
+  LOCALE_ID,
+  TemplateRef,
+  ElementRef,
+  AfterViewInit,
+  inject,
+} from '@angular/core';
+import { Subject, Subscription } from 'rxjs';
+import { WeekDay, CalendarEvent } from 'calendar-utils';
+import {
+  CalendarResource,
+  ResourceWeekView,
+  ResourcesMaxRowNumber,
+  ResourcesMaxRowsNumber,
+} from '../../common/calendar-resource/calendar-resource.interface';
+import {
+  DraggableDirective,
+  DroppableDirective,
+  DropEvent,
+} from 'angular-draggable-droppable';
+import {
+  CalendarEventTimesChangedEvent,
+  CalendarEventTimesChangedEventType,
+} from '../../common/calendar-event-times-changed-event/calendar-event-times-changed-event.interface';
+import { CalendarUtils } from '../../common/calendar-utils/calendar-utils.provider';
+import {
+  validateEvents,
+  addDaysWithExclusions,
+  getWeekViewPeriod,
+} from '../../common/util/util';
+import { DateAdapter } from '../../../date-adapters/date-adapter';
+import { PlacementArray } from 'positioning';
+import { NgClass, NgTemplateOutlet } from '@angular/common';
+import { CalendarResourceWeekViewHeaderComponent } from './calendar-resource-week-view-header/calendar-resource-week-view-header.component';
+import { CalendarResourceWeekViewRowSegmentComponent } from './calendar-resource-week-view-row-segment/calendar-resource-week-view-row-segment.component';
+import { CalendarResourceWeekViewEventComponent } from './calendar-resource-week-view-event/calendar-resource-week-view-event.component';
+
+export interface CalendarResourceWeekViewBeforeRenderEvent
+  extends ResourceWeekView {
+  header: WeekDay[];
+}
+
+export interface CalendarResourceEventTimesChangedEvent
+  extends CalendarEventTimesChangedEvent {
+  resources?: CalendarResource[];
+}
+
+interface ResourceWeekViewDropData {
+  event: CalendarEvent;
+  calendarId: symbol;
+  sourceResource: CalendarResource;
+  sourceDate: Date;
+}
+
+/**
+ * Shows all events on a given week, grouped by resource. Example usage:
+ *
+ * ```typescript
+ * <mwl-calendar-resource-week-view
+ *  [viewDate]="viewDate"
+ *  [events]="events"
+ *  [resources]="resources">
+ * </mwl-calendar-resource-week-view>
+ * ```
+ */
+@Component({
+  selector: 'mwl-calendar-resource-week-view',
+  template: `
+    <div class="cal-resource-week-view" role="grid">
+      <mwl-calendar-resource-week-view-header
+        [days]="days"
+        [locale]="locale"
+        [customTemplate]="headerTemplate"
+        (dayHeaderClicked)="dayHeaderClicked.emit($event)"
+      />
+
+      <div class="cal-time-events cal-resource-events">
+        @if (view.rowColumns.length > 0) {
+          <div class="cal-time-label-column">
+            @for (
+              resourceRow of resourcesMaxRowsNumberAsArray;
+              track $index;
+              let odd = $odd
+            ) {
+              <div class="cal-hour" [class.cal-row-odd]="odd">
+                <mwl-calendar-resource-week-view-row-segment
+                  [style.height.px]="
+                    hourSegmentHeight *
+                    (resourceRow.count > 0 ? resourceRow.count : 1)
+                  "
+                  [segmentHeight]="
+                    hourSegmentHeight *
+                    (resourceRow.count > 0 ? resourceRow.count : 1)
+                  "
+                  [customTemplate]="hourSegmentTemplate"
+                  [resourceLabel]="resourceRow?.resource?.name"
+                  [daysInWeek]="daysInWeek"
+                />
+              </div>
+            }
+          </div>
+        }
+        <div
+          class="cal-day-columns"
+          [class.cal-resize-active]="timeEventResizes.size > 0"
+          #dayColumns
+        >
+          @for (column of view.rowColumns; track column.date.toISOString()) {
+            <div class="cal-day-column">
+              @for (
+                eventsContainer of column.eventsGroupedByResource;
+                track $index;
+                let eventContainerIndex = $index
+              ) {
+                <div
+                  class="cal-events-container"
+                  [style.top]="
+                    view.resourcesMaxRowsNumber[eventContainerIndex].top + 'px'
+                  "
+                >
+                  @if (eventsContainer.events?.length) {
+                    @for (
+                      timeEvent of eventsContainer.events;
+                      track timeEvent.event.id ?? timeEvent.event
+                    ) {
+                      <div
+                        class="cal-event-container"
+                        [ngClass]="timeEvent.event.cssClass"
+                        [class.cal-draggable]="timeEvent.event.draggable"
+                        [hidden]="
+                          timeEvent.height === 0 && timeEvent.width === 0
+                        "
+                        [style.top.px]="timeEvent.top"
+                        [style.height.px]="hourSegmentHeight"
+                        [style.left.%]="0"
+                        [style.width.%]="timeEvent.width"
+                        [style.transform]="
+                          timeEvent.event === draggingEvent
+                            ? 'translateX(' + draggingOffsetX + 'px)'
+                            : null
+                        "
+                        mwlDraggable
+                        dragActiveClass="cal-drag-active"
+                        [dragAxis]="{
+                          x: timeEvent.event.draggable,
+                          y: timeEvent.event.draggable,
+                        }"
+                        [touchStartLongPress]="{ delay: 300, delta: 30 }"
+                        [dropData]="{
+                          event: timeEvent.event,
+                          calendarId: calendarId,
+                          sourceResource: eventsContainer.resource,
+                          sourceDate: column.date,
+                        }"
+                        (dragStart)="onEventDragStart(timeEvent.event)"
+                        (dragging)="onEventDragging($event)"
+                        (dragEnd)="onEventDragEnd()"
+                      >
+                        <ng-template [ngTemplateOutlet]="weekEventTemplate" />
+                        <ng-template #weekEventTemplate>
+                          <mwl-calendar-resource-week-view-event
+                            [locale]="locale"
+                            [weekEvent]="timeEvent"
+                            [tooltipPlacement]="tooltipPlacement"
+                            [tooltipTemplate]="tooltipTemplate"
+                            [tooltipAppendToBody]="tooltipAppendToBody"
+                            [tooltipDelay]="tooltipDelay"
+                            [customTemplate]="eventTemplate"
+                            [eventTitleTemplate]="eventTitleTemplate"
+                            [eventActionsTemplate]="eventActionsTemplate"
+                            [column]="column"
+                            [daysInWeek]="daysInWeek"
+                            (eventClicked)="
+                              eventClicked.emit({
+                                event: timeEvent.event,
+                                sourceEvent: $event.sourceEvent,
+                              })
+                            "
+                          />
+                        </ng-template>
+                      </div>
+                    }
+                  } @else {
+                    <div
+                      class="cal-event-container"
+                      [style.height.px]="hourSegmentHeight"
+                    >
+                      <div [style.height.px]="hourSegmentHeight"></div>
+                    </div>
+                  }
+                </div>
+              }
+
+              @for (
+                row of resourcesMaxRowsNumberAsArray;
+                track $index;
+                let odd = $odd
+              ) {
+                <div
+                  class="cal-hour"
+                  [class.cal-row-odd]="odd"
+                  mwlDroppable
+                  dragOverClass="cal-drag-over"
+                  (drop)="eventDropped($event, column.date, row.resource)"
+                >
+                  <mwl-calendar-resource-week-view-row-segment
+                    [style.height.px]="
+                      hourSegmentHeight * (row.count > 0 ? row.count : 1)
+                    "
+                    [segmentHeight]="
+                      hourSegmentHeight * (row.count > 0 ? row.count : 1)
+                    "
+                    [segment]="{}"
+                    [customTemplate]="hourSegmentTemplate"
+                    [daysInWeek]="daysInWeek"
+                  />
+                </div>
+              }
+            </div>
+          }
+        </div>
+      </div>
+    </div>
+  `,
+  imports: [
+    CalendarResourceWeekViewHeaderComponent,
+    DraggableDirective,
+    DroppableDirective,
+    NgTemplateOutlet,
+    NgClass,
+    CalendarResourceWeekViewRowSegmentComponent,
+    CalendarResourceWeekViewEventComponent,
+  ],
+})
+export class CalendarResourceWeekViewComponent
+  implements OnChanges, OnInit, OnDestroy, AfterViewInit
+{
+  /**
+   * The current view date
+   */
+  @Input() viewDate: Date;
+
+  /**
+   * An array of events to display on view
+   * The schema is available here: https://github.com/mattlewis92/calendar-utils/blob/c51689985f59a271940e30bc4e2c4e1fee3fcb5c/src/calendarUtils.ts#L49-L63
+   */
+  @Input() events: CalendarEvent[] = [];
+
+  /**
+   * An array of resources to display on view
+   */
+  @Input() resources: CalendarResource[] = [];
+
+  /**
+   * An array of day indexes (0 = sunday, 1 = monday etc) that will be hidden on the view
+   */
+  @Input() excludeDays: number[] = [];
+
+  /**
+   * An observable that when emitted on will re-render the current view
+   */
+  @Input() refresh: Subject<any>;
+
+  /**
+   * The locale used to format dates
+   */
+  @Input() locale: string = inject(LOCALE_ID);
+
+  /**
+   * The placement of the event tooltip
+   */
+  @Input() tooltipPlacement: PlacementArray = 'auto';
+
+  /**
+   * A custom template to use for the event tooltips
+   */
+  @Input() tooltipTemplate: TemplateRef<any>;
+
+  /**
+   * Whether to append tooltips to the body or next to the trigger element
+   */
+  @Input() tooltipAppendToBody: boolean = true;
+
+  /**
+   * The delay in milliseconds before the tooltip should be displayed. If not provided the tooltip
+   * will be displayed immediately.
+   */
+  @Input() tooltipDelay: number | null = null;
+
+  /**
+   * The start number of the week.
+   * This is ignored when the `daysInWeek` input is also set as the `viewDate` will be used as the start of the week instead.
+   * Note, you should also pass this to the calendar title pipe so it shows the same days: {{ viewDate | calendarDate:(view + 'ViewTitle'):locale:weekStartsOn }}
+   * If using the moment date adapter this option won't do anything and you'll need to set it globally like so:
+   * ```
+   * moment.updateLocale('en', {
+   *   week: {
+   *     dow: 1, // set start of week to monday instead
+   *     doy: 0,
+   *   },
+   * });
+   * ```
+   */
+  @Input() weekStartsOn: number;
+
+  /**
+   * A custom template to use to replace the header
+   */
+  @Input() headerTemplate: TemplateRef<any>;
+
+  /**
+   * A custom template to use for week view events
+   */
+  @Input() eventTemplate: TemplateRef<any>;
+
+  /**
+   * A custom template to use for event titles
+   */
+  @Input() eventTitleTemplate: TemplateRef<any>;
+
+  /**
+   * A custom template to use for event actions
+   */
+  @Input() eventActionsTemplate: TemplateRef<any>;
+
+  /**
+   * The precision to display events.
+   * `days` will round event start and end dates to the nearest day and `minutes` will not do this rounding
+   */
+  @Input() precision: 'days' | 'minutes' = 'days';
+
+  /**
+   * An array of day indexes (0 = sunday, 1 = monday etc) that indicate which days are weekends
+   */
+  @Input() weekendDays: number[];
+
+  /**
+   * Whether to snap events to a grid when dragging
+   */
+  @Input() snapDraggedEvents: boolean = true;
+
+  /**
+   * The number of segments in an hour. Must divide equally into 60.
+   */
+  @Input() hourSegments: number = 2;
+
+  /**
+   * The duration of each segment group in minutes
+   */
+  @Input() hourDuration: number;
+
+  /**
+   * The height in pixels of each hour segment
+   */
+  @Input() hourSegmentHeight: number = 50;
+
+  /**
+   * The minimum height in pixels of each event
+   */
+  @Input() minimumEventHeight: number = 50;
+
+  /**
+   * The day start hours in 24 hour time. Must be 0-23
+   */
+  @Input() dayStartHour: number = 0;
+
+  /**
+   * The day start minutes. Must be 0-59
+   */
+  @Input() dayStartMinute: number = 0;
+
+  /**
+   * The day end hours in 24 hour time. Must be 0-23
+   */
+  @Input() dayEndHour: number = 23;
+
+  /**
+   * The day end minutes. Must be 0-59
+   */
+  @Input() dayEndMinute: number = 59;
+
+  /**
+   * A custom template to use to replace the hour segment
+   */
+  @Input() hourSegmentTemplate: TemplateRef<any>;
+
+  /**
+   * The grid size to snap resizing and dragging of hourly events to
+   */
+  @Input() eventSnapSize: number;
+
+  /**
+   * A custom template to use for the all day events label text
+   */
+  @Input() allDayEventsLabelTemplate: TemplateRef<any>;
+
+  /**
+   * The number of days in a week. Can be used to create a shorter or longer week view.
+   * The first day of the week will always be the `viewDate` and `weekStartsOn` if set will be ignored
+   */
+  @Input() daysInWeek: number;
+
+  /**
+   * A custom template to use for the current time marker
+   */
+  @Input() currentTimeMarkerTemplate: TemplateRef<any>;
+
+  /**
+   * Should we display events without assigned resources
+   */
+  @Input() keepUnassignedEvents: boolean = true;
+
+  /**
+   * Name to display unassigned resource. This apply only if keepUnassignedEvents is equal to true
+   */
+  @Input() unassignedRessourceName: string = 'Unassigned';
+
+  /**
+   * When dragging an event assigned to several resources, mimic the horizontal movement on
+   * that same event's tile in every other resource row it's also assigned to
+   */
+  @Input() mimicDragAcrossResources: boolean = true;
+
+  /**
+   * Allow you to customise where events can be dragged and resized to.
+   * Return true to allow dragging and resizing to the new location, or false to prevent it
+   */
+  @Input() validateEventTimesChanged: (
+    event: CalendarEventTimesChangedEvent,
+  ) => boolean;
+
+  /**
+   * Called when a header week day is clicked. Adding a `cssClass` property on `$event.day` will add that class to the header element
+   */
+  @Output() dayHeaderClicked = new EventEmitter<{
+    day: WeekDay;
+    sourceEvent: MouseEvent;
+  }>();
+
+  /**
+   * Called when an event title is clicked
+   */
+  @Output() eventClicked = new EventEmitter<{
+    event: CalendarEvent;
+    sourceEvent: MouseEvent | KeyboardEvent;
+  }>();
+
+  /**
+   * Called when an event is dragged and dropped.
+   * If dropped onto another resource's row, `resources` reflects the event's new resources
+   */
+  @Output() eventTimesChanged =
+    new EventEmitter<CalendarResourceEventTimesChangedEvent>();
+
+  /**
+   * An output that will be called before the view is rendered for the current week.
+   * If you add the `cssClass` property to a day in the header it will add that class to the cell element in the template
+   */
+  @Output() beforeViewRender =
+    new EventEmitter<CalendarResourceWeekViewBeforeRenderEvent>();
+
+  /**
+   * Called when an hour segment is clicked
+   */
+  @Output() hourSegmentClicked = new EventEmitter<{
+    date: Date;
+    sourceEvent: MouseEvent;
+  }>();
+
+  /**
+   * @hidden
+   */
+  days: WeekDay[];
+
+  /**
+   * @hidden
+   */
+  view: ResourceWeekView;
+
+  /**
+   * @hidden
+   */
+  resourcesMaxRowsNumberAsArray: ResourcesMaxRowNumber[];
+
+  /**
+   * @hidden
+   */
+  refreshSubscription: Subscription;
+
+  /**
+   * @hidden
+   */
+  timeEventResizes: Map<CalendarEvent, unknown> = new Map();
+
+  /**
+   * @hidden
+   */
+  calendarId = Symbol('angular calendar resource week view id');
+
+  /**
+   * @hidden
+   */
+  rtl = false;
+
+  /**
+   * The event currently being dragged, used to mimic its horizontal movement
+   * across every resource row it's also assigned to
+   * @hidden
+   */
+  draggingEvent: CalendarEvent | null = null;
+
+  /**
+   * @hidden
+   */
+  draggingOffsetX = 0;
+
+  /**
+   * @hidden
+   */
+  protected cdr = inject(ChangeDetectorRef);
+
+  /**
+   * @hidden
+   */
+  protected utils = inject(CalendarUtils);
+
+  /**
+   * @hidden
+   */
+  protected dateAdapter = inject(DateAdapter);
+
+  /**
+   * @hidden
+   */
+  protected element = inject<ElementRef<HTMLElement>>(ElementRef);
+
+  /**
+   * @hidden
+   */
+  ngOnInit(): void {
+    if (this.refresh) {
+      this.refreshSubscription = this.refresh.subscribe(() => {
+        this.refreshAll();
+        this.cdr.markForCheck();
+      });
+    }
+  }
+
+  /**
+   * @hidden
+   */
+  ngOnChanges(changes: any): void {
+    const refreshHeader =
+      changes.viewDate ||
+      changes.excludeDays ||
+      changes.weekendDays ||
+      changes.daysInWeek ||
+      changes.weekStartsOn;
+
+    const refreshBody =
+      changes.viewDate ||
+      changes.dayStartHour ||
+      changes.dayStartMinute ||
+      changes.dayEndHour ||
+      changes.dayEndMinute ||
+      changes.hourSegments ||
+      changes.hourDuration ||
+      changes.weekStartsOn ||
+      changes.weekendDays ||
+      changes.excludeDays ||
+      changes.hourSegmentHeight ||
+      changes.events ||
+      changes.resources ||
+      changes.daysInWeek ||
+      changes.minimumEventHeight ||
+      changes.keepUnassignedEvents ||
+      changes.unassignedRessourceName;
+
+    if (refreshHeader) {
+      this.refreshHeader();
+    }
+
+    if (changes.events) {
+      validateEvents(this.events);
+    }
+
+    if (refreshBody) {
+      this.refreshBody();
+    }
+
+    if (refreshHeader || refreshBody) {
+      this.emitBeforeViewRender();
+    }
+  }
+
+  /**
+   * @hidden
+   */
+  ngOnDestroy(): void {
+    if (this.refreshSubscription) {
+      this.refreshSubscription.unsubscribe();
+    }
+  }
+
+  /**
+   * @hidden
+   */
+  ngAfterViewInit() {
+    this.rtl =
+      typeof window !== 'undefined' &&
+      getComputedStyle(this.element.nativeElement).direction === 'rtl';
+    this.cdr.detectChanges();
+  }
+
+  /**
+   * @hidden
+   */
+  getResourceArrayFromResourceMaxRowNumber(
+    resourcesMaxRowsNumber: ResourcesMaxRowsNumber,
+  ): ResourcesMaxRowNumber[] {
+    const resources = [];
+    for (const resourcesMaxRowNumber in resourcesMaxRowsNumber) {
+      resources.push(resourcesMaxRowsNumber[resourcesMaxRowNumber]);
+    }
+    return resources;
+  }
+
+  /**
+   * @hidden
+   */
+  onEventDragStart(event: CalendarEvent): void {
+    if (!this.mimicDragAcrossResources) {
+      return;
+    }
+    this.draggingEvent = event;
+    this.draggingOffsetX = 0;
+    this.cdr.markForCheck();
+  }
+
+  /**
+   * @hidden
+   */
+  onEventDragging({ x }: { x: number; y: number }): void {
+    if (!this.mimicDragAcrossResources) {
+      return;
+    }
+    this.draggingOffsetX = x;
+    this.cdr.markForCheck();
+  }
+
+  /**
+   * @hidden
+   */
+  onEventDragEnd(): void {
+    this.draggingEvent = null;
+    this.draggingOffsetX = 0;
+    this.cdr.markForCheck();
+  }
+
+  /**
+   * @hidden
+   */
+  eventDropped(
+    dropEvent: Pick<DropEvent<ResourceWeekViewDropData>, 'dropData'>,
+    targetDate: Date,
+    targetResource: CalendarResource,
+  ): void {
+    const dropData = dropEvent.dropData;
+    if (!dropData?.event || dropData.calendarId !== this.calendarId) {
+      return;
+    }
+
+    const { event, sourceResource, sourceDate } = dropData;
+    const sourceId = sourceResource?.id;
+    const targetId = targetResource?.id;
+    const resourceChanged = sourceId !== targetId;
+
+    if (
+      resourceChanged &&
+      targetId !== undefined &&
+      event.resources?.some((resource) => resource.id === targetId)
+    ) {
+      return;
+    }
+
+    let resources = event.resources;
+    if (resourceChanged) {
+      resources =
+        sourceId !== undefined
+          ? (event.resources ?? []).filter(
+              (resource) => resource.id !== sourceId,
+            )
+          : [...(event.resources ?? [])];
+      if (targetId !== undefined) {
+        resources = [...resources, targetResource];
+      }
+    }
+
+    const daysDiff = this.dateAdapter.differenceInDays(targetDate, sourceDate);
+    const newStart = addDaysWithExclusions(
+      this.dateAdapter,
+      event.start,
+      daysDiff,
+      this.excludeDays,
+    );
+    const newEnd = event.end
+      ? addDaysWithExclusions(
+          this.dateAdapter,
+          event.end,
+          daysDiff,
+          this.excludeDays,
+        )
+      : undefined;
+
+    this.eventTimesChanged.emit({
+      type: CalendarEventTimesChangedEventType.Drop,
+      event,
+      newStart,
+      newEnd,
+      resources,
+    });
+  }
+
+  protected refreshHeader(): void {
+    this.days = this.utils.getWeekViewHeader({
+      viewDate: this.viewDate,
+      weekStartsOn: this.weekStartsOn,
+      excluded: this.excludeDays,
+      weekendDays: this.weekendDays,
+      ...getWeekViewPeriod(
+        this.dateAdapter,
+        this.viewDate,
+        this.weekStartsOn,
+        this.excludeDays,
+        this.daysInWeek,
+      ),
+    });
+  }
+
+  protected refreshBody(): void {
+    this.view = this.getResourceWeekView(this.events, this.resources);
+  }
+
+  protected refreshAll(): void {
+    this.refreshHeader();
+    this.refreshBody();
+    this.emitBeforeViewRender();
+  }
+
+  protected emitBeforeViewRender(): void {
+    if (this.days && this.view) {
+      this.beforeViewRender.emit({
+        header: this.days,
+        ...this.view,
+      });
+    }
+  }
+
+  protected getResourceWeekView(
+    events: CalendarEvent[],
+    resources: CalendarResource[],
+  ) {
+    const resourceWeekView = this.utils.getResourceWeekView({
+      events,
+      resources,
+      viewDate: this.viewDate,
+      weekStartsOn: this.weekStartsOn,
+      excluded: this.excludeDays,
+      precision: this.precision,
+      absolutePositionedEvents: true,
+      hourSegments: this.hourSegments,
+      dayStart: {
+        hour: this.dayStartHour,
+        minute: this.dayStartMinute,
+      },
+      dayEnd: {
+        hour: this.dayEndHour,
+        minute: this.dayEndMinute,
+      },
+      segmentHeight: this.hourSegmentHeight,
+      weekendDays: this.weekendDays,
+      minimumEventHeight: this.minimumEventHeight,
+      ...getWeekViewPeriod(
+        this.dateAdapter,
+        this.viewDate,
+        this.weekStartsOn,
+        this.excludeDays,
+        this.daysInWeek,
+      ),
+      keepUnassignedEvents: this.keepUnassignedEvents,
+      unassignedRessourceName: this.unassignedRessourceName,
+    });
+    this.resourcesMaxRowsNumberAsArray =
+      this.getResourceArrayFromResourceMaxRowNumber(
+        resourceWeekView.resourcesMaxRowsNumber,
+      );
+    return resourceWeekView;
+  }
+}

--- a/projects/angular-calendar/src/modules/resource-week/calendar-resource-week-view/calendar-resource-week-view.scss
+++ b/projects/angular-calendar/src/modules/resource-week/calendar-resource-week-view/calendar-resource-week-view.scss
@@ -1,0 +1,244 @@
+@use 'sass:map';
+@use '../../../variables';
+
+$cal-resource-week-view-vars: () !default;
+$cal-resource-week-view-vars: map.merge(
+  variables.$cal-vars,
+  $cal-resource-week-view-vars
+);
+
+@mixin cal-resource-week-view-theme($overrides) {
+  $theme: map.merge($cal-resource-week-view-vars, $overrides);
+
+  .cal-resource-week-view {
+    background-color: map.get($theme, bg-primary);
+    border-top: solid 1px map.get($theme, border-color);
+
+    .cal-day-headers {
+      border-color: map.get($theme, border-color);
+      border-top: 0;
+    }
+
+    .cal-day-headers .cal-header {
+      &:not(:last-child) {
+        border-right-color: map.get($theme, border-color);
+
+        [dir='rtl'] & {
+          border-right-color: initial;
+          border-left: solid 1px map.get($theme, border-color) !important;
+        }
+      }
+
+      &:first-child {
+        border-left-color: map.get($theme, border-color);
+
+        [dir='rtl'] & {
+          border-left-color: initial;
+          border-right-color: map.get($theme, border-color);
+        }
+      }
+    }
+
+    .cal-day-headers .cal-header:hover,
+    .cal-day-headers .cal-drag-over {
+      background-color: map.get($theme, bg-active);
+    }
+
+    .cal-day-column {
+      border-left-color: map.get($theme, border-color);
+
+      [dir='rtl'] & {
+        border-left-color: initial;
+        border-right-color: map.get($theme, border-color);
+      }
+    }
+
+    .cal-event {
+      background-color: map.get($theme, event-color-secondary);
+      border-color: map.get($theme, event-color-primary);
+      color: map.get($theme, event-color-primary);
+    }
+
+    .cal-header.cal-today {
+      background-color: map.get($theme, today-bg);
+    }
+
+    .cal-header.cal-weekend span {
+      color: map.get($theme, weekend-color);
+    }
+
+    .cal-time-events {
+      border-color: map.get($theme, border-color);
+
+      .cal-day-columns {
+        &:not(.cal-resize-active) {
+          .cal-hour-segment:hover {
+            background-color: map.get($theme, bg-active);
+          }
+        }
+      }
+    }
+
+    .cal-hour-odd,
+    .cal-row-odd {
+      background-color: map.get($theme, bg-secondary);
+    }
+
+    .cal-drag-over .cal-hour-segment {
+      background-color: map.get($theme, bg-active);
+    }
+
+    .cal-hour:not(:last-child) .cal-hour-segment,
+    .cal-hour:last-child :not(:last-child) .cal-hour-segment {
+      border-bottom-color: map.get($theme, border-color);
+    }
+  }
+}
+
+.cal-resource-week-view {
+  * {
+    box-sizing: border-box;
+  }
+
+  .cal-day-headers {
+    display: flex;
+    padding-left: 130px;
+    border: 1px solid;
+
+    [dir='rtl'] & {
+      padding-left: initial;
+      padding-right: 130px;
+    }
+  }
+
+  .cal-day-headers .cal-header {
+    flex: 1;
+    text-align: center;
+    padding: 5px;
+
+    &:not(:last-child) {
+      border-right: 1px solid;
+
+      [dir='rtl'] & {
+        border-right: initial;
+        border-left: 1px solid;
+      }
+    }
+
+    &:first-child {
+      border-left: 1px solid;
+
+      [dir='rtl'] & {
+        border-left: initial;
+        border-right: 1px solid;
+      }
+    }
+  }
+
+  .cal-day-headers span {
+    font-weight: 400;
+    opacity: 0.5;
+  }
+
+  .cal-day-column {
+    flex-grow: 1;
+    border-left: solid 1px;
+
+    [dir='rtl'] & {
+      border-left: initial;
+      border-right: solid 1px;
+    }
+  }
+
+  .cal-event {
+    font-size: 12px;
+    border: 1px solid;
+    direction: ltr;
+  }
+
+  .cal-time-label-column {
+    width: 130px;
+  }
+
+  .cal-event,
+  .cal-header {
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
+  .cal-time-events {
+    position: relative;
+    border: solid 1px;
+    border-top: 0;
+    display: flex;
+
+    .cal-day-columns {
+      display: flex;
+      flex-grow: 1;
+    }
+
+    .cal-day-column {
+      position: relative;
+    }
+
+    .cal-events-container {
+      position: relative;
+    }
+
+    .cal-event-container {
+      position: absolute;
+      z-index: 1;
+    }
+
+    .cal-event {
+      width: calc(100% - 2px);
+      height: calc(100% - 2px);
+      margin: 1px;
+      padding: 0 5px;
+      line-height: 25px;
+    }
+  }
+
+  .cal-hour-segment {
+    position: relative;
+    display: block;
+
+    &::after {
+      content: '\00a0';
+    }
+  }
+
+  .cal-event-container {
+    cursor: pointer;
+
+    &.cal-draggable {
+      cursor: move;
+    }
+  }
+
+  .cal-drag-active {
+    pointer-events: none;
+    z-index: 1;
+
+    & * {
+      pointer-events: none;
+    }
+  }
+
+  .cal-hour:not(:last-child) .cal-hour-segment,
+  .cal-hour:last-child :not(:last-child) .cal-hour-segment {
+    border-bottom: thin dashed;
+  }
+
+  .cal-time {
+    font-weight: bold;
+    padding-top: 7px;
+    width: 130px;
+    text-align: center;
+    overflow-y: hidden;
+    height: 100%;
+  }
+}
+
+@include cal-resource-week-view-theme($cal-resource-week-view-vars);

--- a/projects/angular-calendar/src/modules/resource-week/calendar-resource-week.module.ts
+++ b/projects/angular-calendar/src/modules/resource-week/calendar-resource-week.module.ts
@@ -1,0 +1,47 @@
+import { NgModule } from '@angular/core';
+import { DragAndDropModule } from 'angular-draggable-droppable';
+import { CalendarResourceWeekViewComponent } from './calendar-resource-week-view/calendar-resource-week-view.component';
+import { CalendarResourceWeekViewHeaderComponent } from './calendar-resource-week-view/calendar-resource-week-view-header/calendar-resource-week-view-header.component';
+import { CalendarResourceWeekViewEventComponent } from './calendar-resource-week-view/calendar-resource-week-view-event/calendar-resource-week-view-event.component';
+import { CalendarCommonModule } from '../common/calendar-common.module';
+import { CalendarResourceWeekViewRowSegmentComponent } from './calendar-resource-week-view/calendar-resource-week-view-row-segment/calendar-resource-week-view-row-segment.component';
+
+export {
+  CalendarResourceWeekViewComponent,
+  CalendarResourceWeekViewBeforeRenderEvent,
+  CalendarResourceEventTimesChangedEvent,
+} from './calendar-resource-week-view/calendar-resource-week-view.component';
+export {
+  ResourceWeekView as CalendarResourceWeekView,
+  ResourceWeekViewRowColumn as CalendarResourceWeekViewRowColumn,
+  ResourceWeekViewRowEvent as CalendarResourceWeekViewRowEvent,
+  ResourceWeekViewRowSegment as CalendarResourceWeekViewRowSegment,
+  GetResourceWeekViewArgs as CalendarGetResourceWeekViewArgs,
+} from '../common/calendar-resource/calendar-resource.interface';
+export { getWeekViewPeriod } from '../common/util/util';
+
+export { CalendarResourceWeekViewHeaderComponent } from './calendar-resource-week-view/calendar-resource-week-view-header/calendar-resource-week-view-header.component';
+export { CalendarResourceWeekViewEventComponent } from './calendar-resource-week-view/calendar-resource-week-view-event/calendar-resource-week-view-event.component';
+export { CalendarResourceWeekViewRowSegmentComponent } from './calendar-resource-week-view/calendar-resource-week-view-row-segment/calendar-resource-week-view-row-segment.component';
+
+/**
+ * @deprecated import the standalone component `CalendarResourceWeekViewComponent` instead
+ */
+@NgModule({
+  imports: [
+    DragAndDropModule,
+    CalendarCommonModule,
+    CalendarResourceWeekViewComponent,
+    CalendarResourceWeekViewHeaderComponent,
+    CalendarResourceWeekViewEventComponent,
+    CalendarResourceWeekViewRowSegmentComponent,
+  ],
+  exports: [
+    DragAndDropModule,
+    CalendarResourceWeekViewComponent,
+    CalendarResourceWeekViewHeaderComponent,
+    CalendarResourceWeekViewEventComponent,
+    CalendarResourceWeekViewRowSegmentComponent,
+  ],
+})
+export class CalendarResourceWeekModule {}

--- a/projects/angular-calendar/test/package-lock.json
+++ b/projects/angular-calendar/test/package-lock.json
@@ -1,0 +1,6 @@
+{
+  "name": "test",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {}
+}

--- a/projects/demos/app/demo-modules/min-max-date/component.ts
+++ b/projects/demos/app/demo-modules/min-max-date/component.ts
@@ -93,7 +93,7 @@ function endOfPeriod(period: CalendarPeriod, date: Date): Date {
   ],
 })
 export class DemoComponent {
-  view: CalendarView | CalendarPeriod = CalendarView.Month;
+  view: CalendarPeriod = CalendarView.Month;
 
   viewDate: Date = new Date();
 

--- a/projects/demos/app/demo-modules/resource-view/component.ts
+++ b/projects/demos/app/demo-modules/resource-view/component.ts
@@ -1,0 +1,437 @@
+import {
+  Component,
+  ChangeDetectionStrategy,
+  ViewChild,
+  TemplateRef,
+  LOCALE_ID,
+  inject,
+} from '@angular/core';
+import {
+  startOfDay,
+  endOfDay,
+  addDays,
+  endOfMonth,
+  isSameDay,
+  isSameMonth,
+  addHours,
+  startOfWeek,
+} from 'date-fns';
+import { Subject } from 'rxjs';
+import { NgbModal } from '@ng-bootstrap/ng-bootstrap';
+import {
+  CalendarEventAction,
+  CalendarView,
+  CalendarEvent,
+  CalendarResource,
+  CalendarResourceEventTimesChangedEvent,
+  CalendarPreviousViewDirective,
+  CalendarTodayDirective,
+  CalendarNextViewDirective,
+  CalendarDatePipe,
+  CalendarMonthViewComponent,
+  CalendarResourceWeekViewComponent,
+  CalendarResourceDayViewComponent,
+  CalendarTooltipDirective,
+  CalendarEventActionsComponent,
+  ClickDirective,
+  provideCalendar,
+  DateAdapter,
+} from 'angular-calendar';
+import { adapterFactory } from 'angular-calendar/date-adapters/date-fns';
+import { FormsModule } from '@angular/forms';
+import {
+  FlatpickrDirective,
+  provideFlatpickrDefaults,
+} from 'angularx-flatpickr';
+import { JsonPipe, NgStyle } from '@angular/common';
+import { colors } from '../demo-utils/colors';
+
+@Component({
+  selector: 'mwl-demo-component',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  styles: `
+    h3 {
+      margin: 0 0 10px;
+    }
+
+    pre {
+      background-color: #f5f5f5;
+      padding: 15px;
+    }
+
+    .resource-event-time,
+    .resource-event-title {
+      display: block;
+      overflow: hidden;
+      text-overflow: ellipsis;
+      white-space: nowrap;
+      line-height: 1.2;
+      font-size: 11px;
+    }
+  `,
+  templateUrl: 'template.html',
+  imports: [
+    CalendarPreviousViewDirective,
+    CalendarTodayDirective,
+    CalendarNextViewDirective,
+    CalendarDatePipe,
+    CalendarMonthViewComponent,
+    CalendarResourceWeekViewComponent,
+    CalendarResourceDayViewComponent,
+    CalendarTooltipDirective,
+    CalendarEventActionsComponent,
+    ClickDirective,
+    NgStyle,
+    FormsModule,
+    FlatpickrDirective,
+    JsonPipe,
+  ],
+  providers: [
+    provideCalendar({ provide: DateAdapter, useFactory: adapterFactory }),
+    provideFlatpickrDefaults(),
+  ],
+})
+export class DemoComponent {
+  @ViewChild('modalContent', { static: true }) modalContent: TemplateRef<any>;
+
+  @ViewChild('resourceEventTemplate', { static: true })
+  resourceEventTemplate: TemplateRef<any>;
+
+  locale = inject(LOCALE_ID);
+
+  view: CalendarView = CalendarView.Month;
+
+  CalendarView = CalendarView;
+
+  viewDate: Date = new Date();
+
+  modalData: {
+    action: string;
+    event: CalendarEvent;
+  };
+
+  actions: CalendarEventAction[] = [
+    {
+      label: '<i class="fas fa-fw fa-pencil-alt"></i>',
+      a11yLabel: 'Edit',
+      onClick: ({ event }: { event: CalendarEvent }): void => {
+        this.handleEvent('Edited', event);
+      },
+    },
+    {
+      label: '<i class="fas fa-fw fa-trash-alt"></i>',
+      a11yLabel: 'Delete',
+      onClick: ({ event }: { event: CalendarEvent }): void => {
+        this.events = this.events.filter((iEvent) => iEvent !== event);
+        this.handleEvent('Deleted', event);
+      },
+    },
+  ];
+
+  refresh = new Subject<void>();
+
+  resources: CalendarResource[] = [
+    {
+      id: 1,
+      name: 'Edoinise',
+    },
+    {
+      id: 2,
+      name: 'Jean-Donald',
+    },
+    {
+      id: 3,
+      name: 'Laeticia',
+    },
+    {
+      id: 4,
+      name: 'Mateo',
+    },
+    {
+      id: 5,
+      name: 'Khephren',
+    },
+  ];
+
+  events: CalendarEvent[] = [
+    {
+      id: 1247,
+      start: addHours(startOfWeek(new Date()), 8),
+      end: addHours(startOfWeek(new Date()), 12),
+      title: 'Workshop with Dassault System',
+      color: { ...colors.yellow },
+      actions: this.actions,
+      allDay: false,
+      draggable: true,
+      resources: [this.getResourceById(1), this.getResourceById(4)],
+    },
+    {
+      id: 1248,
+      start: addHours(addDays(startOfWeek(new Date()), 1), 8),
+      end: addHours(addDays(startOfWeek(new Date()), 1), 12),
+      title: 'Workshop with Google',
+      color: { ...colors.yellow },
+      actions: this.actions,
+      allDay: false,
+      draggable: true,
+      resources: [this.getResourceById(1), this.getResourceById(4)],
+    },
+    {
+      id: 1249,
+      start: addHours(addDays(startOfWeek(new Date()), 3), 8),
+      end: addHours(addDays(startOfWeek(new Date()), 3), 12),
+      title: 'Workshop with Netflix',
+      color: { ...colors.yellow },
+      actions: this.actions,
+      allDay: false,
+      draggable: true,
+      resources: [this.getResourceById(1), this.getResourceById(2)],
+    },
+    {
+      id: 1250,
+      start: addHours(startOfWeek(new Date()), 14),
+      end: addHours(startOfWeek(new Date()), 18),
+      title: 'Product demonstration',
+      color: { ...colors.yellow },
+      actions: this.actions,
+      allDay: false,
+      draggable: true,
+      resources: [this.getResourceById(2), this.getResourceById(4)],
+    },
+    {
+      id: 1251,
+      start: addHours(addDays(startOfWeek(new Date()), 2), 8),
+      end: addHours(addDays(startOfWeek(new Date()), 2), 12),
+      title: 'Call for tenders',
+      color: { ...colors.yellow },
+      actions: this.actions,
+      allDay: false,
+      draggable: true,
+      resources: [this.getResourceById(3)],
+    },
+    {
+      id: 1252,
+      start: addHours(addDays(startOfWeek(new Date()), 4), 14),
+      end: addHours(addDays(startOfWeek(new Date()), 4), 18),
+      title: 'Call for tenders',
+      color: { ...colors.yellow },
+      actions: this.actions,
+      allDay: false,
+      draggable: true,
+      resources: [this.getResourceById(3)],
+    },
+    {
+      id: 1253,
+      start: addHours(addDays(startOfWeek(new Date()), 4), 8),
+      end: addHours(addDays(startOfWeek(new Date()), 4), 12),
+      title: 'Workshop with Amazon',
+      color: { ...colors.yellow },
+      actions: this.actions,
+      allDay: false,
+      draggable: true,
+      resources: [
+        this.getResourceById(1),
+        this.getResourceById(3),
+        this.getResourceById(5),
+      ],
+    },
+    {
+      id: 1254,
+      start: addHours(addDays(startOfWeek(new Date()), 3), 8),
+      end: addHours(addDays(startOfWeek(new Date()), 3), 12),
+      title: 'Customer weekly meeting',
+      color: { ...colors.yellow },
+      actions: this.actions,
+      allDay: false,
+      draggable: true,
+      resources: [this.getResourceById(5)],
+    },
+    {
+      id: 1255,
+      start: addHours(addDays(startOfWeek(new Date()), 3), 13),
+      end: addHours(addDays(startOfWeek(new Date()), 3), 15),
+      title: 'App Insight Verification',
+      color: { ...colors.yellow },
+      actions: this.actions,
+      allDay: false,
+      draggable: true,
+      resources: [this.getResourceById(5)],
+    },
+    {
+      id: 1256,
+      start: addHours(addDays(startOfWeek(new Date()), 3), 15),
+      end: addHours(addDays(startOfWeek(new Date()), 3), 19),
+      title: 'Customers Tickets Review',
+      color: { ...colors.yellow },
+      actions: this.actions,
+      allDay: false,
+      draggable: true,
+      resources: [this.getResourceById(5)],
+    },
+    {
+      id: 1257,
+      start: addHours(addDays(startOfWeek(new Date()), 5), 8),
+      end: addHours(addDays(startOfWeek(new Date()), 5), 12),
+      title: 'Team Building',
+      color: { ...colors.yellow },
+      actions: this.actions,
+      allDay: true,
+      draggable: true,
+      resources: [
+        this.getResourceById(1),
+        this.getResourceById(2),
+        this.getResourceById(3),
+        this.getResourceById(4),
+        this.getResourceById(5),
+      ],
+    },
+    {
+      id: 1258,
+      start: startOfWeek(new Date()),
+      end: addDays(startOfWeek(new Date()), 2),
+      title: 'A 3 day event',
+      color: { ...colors.red },
+      actions: this.actions,
+      allDay: true,
+      draggable: true,
+    },
+    {
+      id: 1259,
+      start: startOfDay(new Date()),
+      title: 'An event with no end date',
+      color: { ...colors.yellow },
+      actions: this.actions,
+      draggable: true,
+    },
+    {
+      id: 1260,
+      start: addDays(startOfWeek(new Date()), 3),
+      end: addDays(endOfMonth(new Date()), 3),
+      title: 'A long event that spans 2 months',
+      color: { ...colors.blue },
+      allDay: true,
+      draggable: true,
+    },
+  ];
+
+  activeDayIsOpen: boolean = true;
+
+  mimicDragAcrossResources: boolean = true;
+
+  keepUnassignedEvents: boolean = true;
+
+  unassignedRessourceName: string = 'Unassigned';
+
+  private modal = inject(NgbModal);
+
+  dayClicked({ date, events }: { date: Date; events: CalendarEvent[] }): void {
+    if (isSameMonth(date, this.viewDate)) {
+      if (
+        (isSameDay(this.viewDate, date) && this.activeDayIsOpen === true) ||
+        events.length === 0
+      ) {
+        this.activeDayIsOpen = false;
+      } else {
+        this.activeDayIsOpen = true;
+      }
+      this.viewDate = date;
+    }
+  }
+
+  handleEvent(action: string, event: CalendarEvent): void {
+    this.modalData = { event, action };
+    this.modal.open(this.modalContent, { size: 'lg' });
+  }
+
+  addEvent(): void {
+    this.events = [
+      ...this.events,
+      {
+        title: 'New event',
+        start: startOfDay(new Date()),
+        end: endOfDay(new Date()),
+        color: colors.red,
+        draggable: true,
+        resizable: {
+          beforeStart: true,
+          afterEnd: true,
+        },
+      },
+    ];
+  }
+
+  deleteEvent(eventToDelete: CalendarEvent) {
+    this.events = this.events.filter((event) => event !== eventToDelete);
+  }
+
+  eventTimesChanged({
+    event,
+    newStart,
+    newEnd,
+    resources,
+  }: CalendarResourceEventTimesChangedEvent): void {
+    event.start = newStart;
+    event.end = newEnd;
+    if (resources) {
+      event.resources = resources;
+    }
+    this.events = [...this.events];
+  }
+
+  isResourceAssigned(
+    event: CalendarEvent,
+    resource: CalendarResource,
+  ): boolean {
+    return !!event.resources?.some(
+      (eventResource) => eventResource.id === resource.id,
+    );
+  }
+
+  updateEventResources(event: CalendarEvent, changeEvent: Event): void {
+    const selectedIds = Array.from(
+      (changeEvent.target as HTMLSelectElement).selectedOptions,
+    ).map((option) => option.value);
+    event.resources = this.resources.filter((resource) =>
+      selectedIds.includes(String(resource.id)),
+    );
+    this.refresh.next();
+  }
+
+  addResource(): void {
+    const nextId =
+      this.resources.reduce(
+        (maxId, resource) => Math.max(maxId, Number(resource.id) || 0),
+        0,
+      ) + 1;
+    this.resources = [...this.resources, { id: nextId, name: 'New resource' }];
+  }
+
+  deleteResource(resourceToDelete: CalendarResource): void {
+    this.resources = this.resources.filter(
+      (resource) => resource !== resourceToDelete,
+    );
+    this.events = this.events.map((event) =>
+      event.resources?.some((resource) => resource === resourceToDelete)
+        ? {
+            ...event,
+            resources: event.resources.filter(
+              (resource) => resource !== resourceToDelete,
+            ),
+          }
+        : event,
+    );
+    this.refresh.next();
+  }
+
+  setView(view: CalendarView) {
+    this.view = view;
+  }
+
+  closeOpenMonthViewDay() {
+    this.activeDayIsOpen = false;
+  }
+
+  private getResourceById(id: number): CalendarResource {
+    return this.resources.find((resource) => resource.id === id);
+  }
+}

--- a/projects/demos/app/demo-modules/resource-view/sources.ts
+++ b/projects/demos/app/demo-modules/resource-view/sources.ts
@@ -1,0 +1,15 @@
+// @ts-expect-error TypeScript cannot provide types based on attributes yet
+import component from './component' with { loader: 'text' };
+// @ts-expect-error TypeScript cannot provide types based on attributes yet
+import template from './template.html' with { loader: 'text' };
+
+export const sources = [
+  {
+    filename: 'component.ts',
+    contents: component,
+  },
+  {
+    filename: 'template.html',
+    contents: template,
+  },
+];

--- a/projects/demos/app/demo-modules/resource-view/template.html
+++ b/projects/demos/app/demo-modules/resource-view/template.html
@@ -1,0 +1,356 @@
+<div class="row text-center">
+  <div class="col-md-4">
+    <div class="btn-group">
+      <div
+        class="btn btn-primary"
+        mwlCalendarPreviousView
+        [view]="view"
+        [(viewDate)]="viewDate"
+        (viewDateChange)="closeOpenMonthViewDay()"
+      >
+        Previous
+      </div>
+      <div
+        class="btn btn-outline-secondary"
+        mwlCalendarToday
+        [(viewDate)]="viewDate"
+      >
+        Today
+      </div>
+      <div
+        class="btn btn-primary"
+        mwlCalendarNextView
+        [view]="view"
+        [(viewDate)]="viewDate"
+        (viewDateChange)="closeOpenMonthViewDay()"
+      >
+        Next
+      </div>
+    </div>
+  </div>
+  <div class="col-md-4">
+    <h3>{{ viewDate | calendarDate:(view + 'ViewTitle'):'en' }}</h3>
+  </div>
+  <div class="col-md-4">
+    <div class="btn-group">
+      <div
+        class="btn btn-primary"
+        (click)="setView(CalendarView.Month)"
+        [class.active]="view === CalendarView.Month"
+      >
+        Month
+      </div>
+      <div
+        class="btn btn-primary"
+        (click)="setView(CalendarView.Week)"
+        [class.active]="view === CalendarView.Week"
+      >
+        Week
+      </div>
+      <div
+        class="btn btn-primary"
+        (click)="setView(CalendarView.Day)"
+        [class.active]="view === CalendarView.Day"
+      >
+        Day
+      </div>
+    </div>
+  </div>
+</div>
+<br />
+<div>
+  @switch (view) { @case (CalendarView.Month) {
+  <mwl-calendar-month-view
+    [viewDate]="viewDate"
+    [events]="events"
+    [refresh]="refresh"
+    [activeDayIsOpen]="activeDayIsOpen"
+    (dayClicked)="dayClicked($event.day)"
+    (eventClicked)="handleEvent('Clicked', $event.event)"
+  />
+  } @case (CalendarView.Week) {
+  <mwl-calendar-resource-week-view
+    [viewDate]="viewDate"
+    [events]="events"
+    [refresh]="refresh"
+    [resources]="resources"
+    [mimicDragAcrossResources]="mimicDragAcrossResources"
+    [keepUnassignedEvents]="keepUnassignedEvents"
+    [unassignedRessourceName]="unassignedRessourceName"
+    [eventTemplate]="resourceEventTemplate"
+    [hourSegmentHeight]="60"
+    (eventClicked)="handleEvent('Clicked', $event.event)"
+    (eventTimesChanged)="eventTimesChanged($event)"
+  />
+  } @case (CalendarView.Day) {
+  <mwl-calendar-resource-day-view
+    [viewDate]="viewDate"
+    [events]="events"
+    [refresh]="refresh"
+    [resources]="resources"
+    [mimicDragAcrossResources]="mimicDragAcrossResources"
+    [keepUnassignedEvents]="keepUnassignedEvents"
+    [unassignedRessourceName]="unassignedRessourceName"
+    [eventTemplate]="resourceEventTemplate"
+    [hourSegmentHeight]="60"
+    (eventClicked)="handleEvent('Clicked', $event.event)"
+    (eventTimesChanged)="eventTimesChanged($event)"
+  />
+  } }
+</div>
+
+<ng-template
+  #resourceEventTemplate
+  let-weekEvent="weekEvent"
+  let-tooltipPlacement="tooltipPlacement"
+  let-eventClicked="eventClicked"
+  let-tooltipTemplate="tooltipTemplate"
+  let-tooltipAppendToBody="tooltipAppendToBody"
+  let-tooltipDisabled="tooltipDisabled"
+  let-tooltipDelay="tooltipDelay"
+  let-daysInWeek="daysInWeek"
+>
+  <div
+    class="cal-event"
+    [ngStyle]="{
+      color: weekEvent.event.color?.secondaryText,
+      backgroundColor: weekEvent.event.color?.secondary,
+      borderColor: weekEvent.event.color?.primary
+    }"
+    [mwlCalendarTooltip]="!tooltipDisabled ? weekEvent.event.title : ''"
+    [tooltipPlacement]="tooltipPlacement"
+    [tooltipEvent]="weekEvent.tempEvent || weekEvent.event"
+    [tooltipTemplate]="tooltipTemplate"
+    [tooltipAppendToBody]="tooltipAppendToBody"
+    [tooltipDelay]="tooltipDelay"
+    (mwlClick)="eventClicked.emit({ sourceEvent: $event })"
+    tabindex="0"
+  >
+    <mwl-calendar-event-actions
+      [event]="weekEvent.tempEvent || weekEvent.event"
+    />
+    @if (!weekEvent.event.allDay) {
+    <div class="resource-event-time">
+      {{ weekEvent.event.start | calendarDate: (daysInWeek === 1 ? 'dayViewHour'
+      : 'weekViewHour') : locale }} @if (weekEvent.event.end) { - {{
+      weekEvent.event.end | calendarDate: (daysInWeek === 1 ? 'dayViewHour' :
+      'weekViewHour') : locale }} } |
+    </div>
+    }
+    <div class="resource-event-title">
+      {{ weekEvent.tempEvent?.title || weekEvent.event.title }}
+    </div>
+  </div>
+</ng-template>
+
+<div class="form-check" style="margin-top: 20px">
+  <input
+    type="checkbox"
+    class="form-check-input"
+    id="mimicDragAcrossResources"
+    [(ngModel)]="mimicDragAcrossResources"
+  />
+  <label class="form-check-label" for="mimicDragAcrossResources">
+    Mimic dragged event across the resources it's assigned to
+  </label>
+</div>
+
+<div class="form-check" style="margin-top: 10px">
+  <input
+    type="checkbox"
+    class="form-check-input"
+    id="keepUnassignedEvents"
+    [(ngModel)]="keepUnassignedEvents"
+  />
+  <label class="form-check-label" for="unassignedRessourceName">
+    Unassigned resource label
+  </label>
+  <input
+    type="text"
+    id="unassignedRessourceName"
+    class="form-control d-inline-block"
+    style="width: auto; margin-left: 10px"
+    [(ngModel)]="unassignedRessourceName"
+    [disabled]="!keepUnassignedEvents"
+    (ngModelChange)="refresh.next()"
+  />
+</div>
+
+<!-- Everything you see below is just for the demo, you don't need to include it in your app -->
+
+<br /><br /><br />
+
+<h3>
+  Edit resources
+  <button class="btn btn-primary float-end" (click)="addResource()">
+    Add new
+  </button>
+  <div class="clearfix"></div>
+</h3>
+
+<div class="table-responsive">
+  <table class="table table-bordered">
+    <thead>
+      <tr>
+        <th>Name</th>
+        <th>Remove</th>
+      </tr>
+    </thead>
+
+    <tbody>
+      @for (resource of resources; track resource.id) {
+      <tr>
+        <td>
+          <input
+            type="text"
+            class="form-control"
+            [(ngModel)]="resource.name"
+            (keyup)="refresh.next()"
+          />
+        </td>
+        <td>
+          <button class="btn btn-danger" (click)="deleteResource(resource)">
+            Delete
+          </button>
+        </td>
+      </tr>
+      }
+    </tbody>
+  </table>
+</div>
+
+<br /><br /><br />
+
+<h3>
+  Edit events
+  <button class="btn btn-primary float-end" (click)="addEvent()">
+    Add new
+  </button>
+  <div class="clearfix"></div>
+</h3>
+
+<div class="table-responsive">
+  <table class="table table-bordered">
+    <thead>
+      <tr>
+        <th>Title</th>
+        <th>Primary color</th>
+        <th>Secondary + text color</th>
+        <th>Starts at</th>
+        <th>Ends at</th>
+        <th>Resources</th>
+        <th>Remove</th>
+      </tr>
+    </thead>
+
+    <tbody>
+      @for (event of events; track event) {
+      <tr>
+        <td>
+          <input
+            type="text"
+            class="form-control"
+            [(ngModel)]="event.title"
+            (keyup)="refresh.next()"
+          />
+        </td>
+        <td>
+          <input
+            type="color"
+            [(ngModel)]="event.color.primary"
+            (change)="refresh.next()"
+          />
+        </td>
+        <td>
+          <input
+            type="color"
+            [(ngModel)]="event.color.secondary"
+            (change)="refresh.next()"
+          />
+          <input
+            type="color"
+            [ngModel]="event.color.secondaryText ?? '#1e90ff'"
+            (ngModelChange)="event.color.secondaryText = $event"
+            (change)="refresh.next()"
+          />
+        </td>
+        <td>
+          <input
+            class="form-control"
+            type="text"
+            mwlFlatpickr
+            [(ngModel)]="event.start"
+            (ngModelChange)="refresh.next()"
+            [altInput]="true"
+            [convertModelValue]="true"
+            [enableTime]="true"
+            dateFormat="Y-m-dTH:i"
+            altFormat="F j, Y H:i"
+            placeholder="Not set"
+          />
+        </td>
+        <td>
+          <input
+            class="form-control"
+            type="text"
+            mwlFlatpickr
+            [(ngModel)]="event.end"
+            (ngModelChange)="refresh.next()"
+            [altInput]="true"
+            [convertModelValue]="true"
+            [enableTime]="true"
+            dateFormat="Y-m-dTH:i"
+            altFormat="F j, Y H:i"
+            placeholder="Not set"
+          />
+        </td>
+        <td>
+          <select
+            class="form-control"
+            multiple
+            (change)="updateEventResources(event, $event)"
+          >
+            @for (resource of resources; track resource.id) {
+            <option
+              [value]="resource.id"
+              [selected]="isResourceAssigned(event, resource)"
+            >
+              {{ resource.name }}
+            </option>
+            }
+          </select>
+        </td>
+        <td>
+          <button class="btn btn-danger" (click)="deleteEvent(event)">
+            Delete
+          </button>
+        </td>
+      </tr>
+      }
+    </tbody>
+  </table>
+</div>
+
+<ng-template #modalContent let-close="close">
+  <div class="modal-header">
+    <h5 class="modal-title">Event action occurred</h5>
+    <button type="button" class="close" (click)="close()">
+      <span aria-hidden="true">&times;</span>
+    </button>
+  </div>
+  <div class="modal-body">
+    <div>
+      Action:
+      <pre>{{ modalData?.action }}</pre>
+    </div>
+    <div>
+      Event:
+      <pre>{{ modalData?.event | json }}</pre>
+    </div>
+  </div>
+  <div class="modal-footer">
+    <button type="button" class="btn btn-outline-secondary" (click)="close()">
+      OK
+    </button>
+  </div>
+</ng-template>

--- a/projects/demos/main.ts
+++ b/projects/demos/main.ts
@@ -401,6 +401,16 @@ bootstrapApplication(DemoAppComponent, {
           },
         },
         {
+          path: 'resource-view',
+          loadComponent: () =>
+            import('./app/demo-modules/resource-view/component').then(
+              (c) => c.DemoComponent,
+            ),
+          data: {
+            label: 'Resource view',
+          },
+        },
+        {
           path: 'day-view-scheduler',
           loadComponent: () =>
             import('./app/demo-modules/day-view-scheduler/component').then(


### PR DESCRIPTION
Introduce a "resource" scheduling mode that groups and drags events by an
assigned resource (a person, room, or any other bookable entity), alongside
the existing date/time based week and day views.

- Add `CalendarResourceWeekViewComponent` and `CalendarResourceDayViewComponent`,
  standalone components rendering one row per resource and one column per day,
  grouping each day's events under the resource(s) they're assigned to.
- Add a `resources` input (`CalendarResource[]`) and a `resources?` property on
  `CalendarEvent` to associate an event with one or more resources.
- Add `keepUnassignedEvents` / `unassignedRessourceName` inputs to control
  whether events with no resource are shown in a dedicated "Unassigned" row.
- Add drag & drop support in the resource week/day views:
  - Dragging an event horizontally changes its day only; its time and assigned
    resources are left untouched.
  - Dragging an event vertically onto another resource's row reassigns it,
    replacing the source resource with the target resource.
  - Dropping onto a resource the event is already assigned to cancels the move.
  - Add a `mimicDragAcrossResources` input (default `true`): while dragging an
    event assigned to several resources, it mirrors the horizontal movement on
    that event's tile in every other resource row it's also assigned to.
- Add `CalendarView.ResourceWeek` / `CalendarView.ResourceDay` enum members.
- Add a `resource-view` demo showing resource management (add/rename/delete),
  optional per-event resource assignment, and drag & drop between resources.
- Export `CalendarResource`, `CalendarResourceIdType`, `getResourceWeekView`
  and the related `ResourceWeekView*` types from the public API.